### PR TITLE
Major improvements to web watcher UX

### DIFF
--- a/app/client.js
+++ b/app/client.js
@@ -1,7 +1,13 @@
 "use strict";
 
+function isDevMode() {
+  // Found here: https://stackoverflow.com/a/20227975/965332
+  return !('update_url' in chrome.runtime.getManifest())
+}
+
 var client = {
-  testing: false,
+  testing: isDevMode(),
+  lastSyncSuccess: true,
   _getHost: function(){
     if(this.testing) {
       return "http://127.0.0.1:5666/";
@@ -35,11 +41,11 @@ var client = {
     xhr.onreadystatechange = function() {
       if (xhr.readyState === XMLHttpRequest.DONE) {
         if (xhr.status === 200){
-          var resp = JSON.parse(xhr.responseText);
+          let resp = JSON.parse(xhr.responseText);
           console.log("Bucket was successfully created");
         }
         else if (xhr.status === 400){
-          var resp = JSON.parse(xhr.responseText);
+          let resp = JSON.parse(xhr.responseText);
           console.log("Bucket already created");
         }
         else {
@@ -56,15 +62,30 @@ var client = {
     var xhr = new XMLHttpRequest();
     xhr.open("POST", url, true);
     xhr.setRequestHeader('Content-Type', 'application/json; charset=utf-8');
+
     xhr.onreadystatechange = function() {
       // xhr.readyState === 4 means DONE with request
       if (xhr.readyState === 4) {
-        if (xhr.status != 200){
+        if (xhr.status !== 200){
+          // ERROR
           console.error("Status code: " + xhr.status + ", response: " + xhr.responseText);
+          if(client.lastSyncSuccess) {
+            chrome.notifications.create({
+              "type": "basic",
+              "iconUrl": chrome.extension.getURL("media/logo/logo.png"),
+              "title": "Unable to send event to server",
+              "message": "Please ensure that you are running an ActivityWatch server at: " + client._getHost(),
+            });
+            client.lastSyncSuccess = false;
+          }
+        } else {
+          // SUCCESS
+          client.lastSyncSuccess = true;
+          chrome.storage.local.set({"lastSync": new Date().toISOString()});
         }
       }
     };
-    var payload = JSON.stringify({"data": data, "timestamp": timestamp.toISOString()})
+    var payload = JSON.stringify({"data": data, "timestamp": timestamp.toISOString()});
     xhr.send(payload);
   }
-}
+};

--- a/app/client.js
+++ b/app/client.js
@@ -46,10 +46,10 @@ var client = {
         }
         else if (xhr.status === 400){
           let resp = JSON.parse(xhr.responseText);
-          console.log("Bucket already created");
+          //console.log("Bucket already created");
         }
         else {
-          console.error("Couldn't connect to server: "+ xhr.status);
+          console.error("Unable to create bucket (statuscode: " + xhr.status + ")");
         }
       }
     };

--- a/app/eventPage.js
+++ b/app/eventPage.js
@@ -41,22 +41,22 @@ function heartbeat(tab) {
   var data = {"url": tab.url, "title": tab.title, "audible": tab.audible, "incognito": tab.incognito};
   // First heartbeat on startup
   if (last_heartbeat_time === null){
-    console.log("aw-watcher-web: First");
+    //console.log("aw-watcher-web: First");
     client.sendHeartbeat(now, data, heartbeat_pulsetime);
     last_heartbeat_data = data;
     last_heartbeat_time = now;
   }
   // Any tab data has changed, finish previous event and insert new event
   else if (JSON.stringify(last_heartbeat_data) != JSON.stringify(data)){
-    console.log("aw-watcher-web: Change");
+    //console.log("aw-watcher-web: Change");
     client.sendHeartbeat(new Date(now-1), last_heartbeat_data, heartbeat_pulsetime);
     client.sendHeartbeat(now, data, heartbeat_pulsetime);
     last_heartbeat_data = data;
     last_heartbeat_time = now;
   }
-  // If heartbeat interval has benn exceeded
+  // If heartbeat interval has been exceeded
   else if (new Date(last_heartbeat_time.getTime()+(heartbeat_interval*1000)) < now){
-    console.log("aw-watcher-web: Update");
+    //console.log("aw-watcher-web: Update");
     client.sendHeartbeat(now, data, heartbeat_pulsetime);
     last_heartbeat_time = now;
   }
@@ -73,7 +73,7 @@ chrome.alarms.onAlarm.addListener(function(alarm) {
       if(tabs.length >= 1) {
         heartbeat(tabs[0]);
       } else {
-        console.log("tabs had length < 0");
+        //console.log("tabs had length < 0");
       }
       createAlarm();
     });

--- a/app/popup.html
+++ b/app/popup.html
@@ -15,6 +15,19 @@
 
   <hr>
 
+  <div>
+    <a id="webui-link" href="http://localhost:5600/" target="_blank">
+      <span class="button">
+        <b>Open web UI</b>
+      </span>
+    </a>
+    <a href="https://forum.activitywatch.net/" target="_blank">
+      <span class="button">
+        <b>Visit forum</b>
+      </span>
+    </a>
+  </div>
+
   <div id="status">
     <!-- Filled by JS -->
   </div>

--- a/app/popup.html
+++ b/app/popup.html
@@ -11,17 +11,37 @@
 </head>
 
 <body>
-  <h4>Status: <span id="status"></span></h4>
+  <img src="/media/banners/banner.png" style="width: 100%">
 
-  <p>
-    Please note that this web browser watcher is in an early stage of development.<br>
-    File all bugs you find <a href="https://github.com/ActivityWatch/aw-watcher-web/issues">here</a>.
-  </p>
+  <hr>
 
-  <h5>Debug info:</h5>
-  <code>
-    <pre id="debug"></pre>
-  </code>
+  <div id="status">
+    <!-- Filled by JS -->
+  </div>
+
+  <hr>
+
+  <small>
+    <p>
+      Please note that this web browser watcher is in an early stage of development.<br>
+    </p>
+
+    <p>
+      File all bugs you find <a href="https://github.com/ActivityWatch/aw-watcher-web/issues">here</a>.
+    </p>
+  </small>
+
+  <hr>
+
+  <details style="background-color: #DDD; padding: 0.4em; border-radius: 0.4em;">
+    <summary>
+      Debug info
+    </summary>
+
+    <code>
+      <pre id="debug"><!-- Filled by JS --></pre>
+    </code>
+  </details>
 </body>
 
 </html>

--- a/app/popup_files/popup.js
+++ b/app/popup_files/popup.js
@@ -21,6 +21,7 @@ function getCurrentTabs(callback) {
 
 function renderStatus() {
   chrome.storage.local.get(["lastSync"], function(obj) {
+    let lastSyncString = obj.lastSync ? new Date(obj.lastSync).toLocaleString() : "never";
     var msg = "<table>";
     msg += "<tr>" +
       "<th>Running:</th>" + "<td style='color: #00AA00; font-size: 1.5em;'>✔</td>" +
@@ -31,7 +32,7 @@ function renderStatus() {
       "</tr>";
     }
     msg += "<tr>" +
-      "<th>Last sync:</th>" + "<td>" + (new Date(obj.lastSync).toLocaleString() || never) + "</td>" +
+      "<th>Last sync:</th>" + "<td>" + lastSyncString + "</td>" +
     "</tr>";
     msg += "</table>";
     document.getElementById('status').innerHTML = msg;

--- a/app/popup_files/popup.js
+++ b/app/popup_files/popup.js
@@ -35,6 +35,7 @@ function renderStatus() {
     "</tr>";
     msg += "</table>";
     document.getElementById('status').innerHTML = msg;
+    document.getElementById('webui-link').href = client._getHost();
   });
 }
 

--- a/app/popup_files/popup.js
+++ b/app/popup_files/popup.js
@@ -21,7 +21,6 @@ function getCurrentTabs(callback) {
 
 function renderStatus() {
   chrome.storage.local.get(["lastSync"], function(obj) {
-    console.log(JSON.stringify(obj));
     var msg = "<table>";
     msg += "<tr>" +
       "<th>Running:</th>" + "<td style='color: #00AA00; font-size: 1.5em;'>✔</td>" +
@@ -40,8 +39,8 @@ function renderStatus() {
 }
 
 function renderDebug(msg) {
-  document.getElementById('debug').textContent = msg;
-  document.getElementById('debug').innerHTML = "<br>" + JSON.stringify(client);
+  document.getElementById('debug').innerHTML = msg;
+  document.getElementById('debug').innerHTML += "<br>" + JSON.stringify(client);
 }
 
 document.addEventListener('DOMContentLoaded', function() {

--- a/app/popup_files/popup.js
+++ b/app/popup_files/popup.js
@@ -19,18 +19,36 @@ function getCurrentTabs(callback) {
   });
 }
 
-function renderStatus(msg) {
-  document.getElementById('status').textContent = msg;
+function renderStatus() {
+  chrome.storage.local.get(["lastSync"], function(obj) {
+    console.log(JSON.stringify(obj));
+    var msg = "<table>";
+    msg += "<tr>" +
+      "<th>Running:</th>" + "<td style='color: #00AA00; font-size: 1.5em;'>✔</td>" +
+    "</tr>";
+    if(client.testing == true) {
+      msg += "<tr>" +
+        "<th>Testing:</th>" + "<td style='color: #FF8800; font-size: 1.5em;'>✔</td>" +
+      "</tr>";
+    }
+    msg += "<tr>" +
+      "<th>Last sync:</th>" + "<td>" + (new Date(obj.lastSync).toLocaleString() || never) + "</td>" +
+    "</tr>";
+    msg += "</table>";
+    document.getElementById('status').innerHTML = msg;
+  });
 }
 
 function renderDebug(msg) {
   document.getElementById('debug').textContent = msg;
+  document.getElementById('debug').innerHTML = "<br>" + JSON.stringify(client);
 }
 
 document.addEventListener('DOMContentLoaded', function() {
   getCurrentTabs(function(tabs) {
     // Status title
-    renderStatus("ActivityWatch ready to watch");
+    renderStatus();
+
     // Debug info
     var text = "";
     text += "Number of active tabs: " + tabs.length + "\n";

--- a/app/popup_files/style.css
+++ b/app/popup_files/style.css
@@ -4,6 +4,24 @@ body {
   width: 25em;
 }
 
+hr {
+  border: 1px solid #DDD;
+}
+
+a {
+  text-decoration: none;
+}
+
+.button {
+  display: inline-block;
+  color: #333333;
+  padding: 0.5em;
+  margin: 0.5em 0 0.5em 0.5em;
+  border-radius: 0.2em;
+  background-color: #EEE;
+  border: 1px solid #DDD;
+}
+
 #status {
   /* avoid an excessively wide status text */
   white-space: pre;

--- a/app/popup_files/style.css
+++ b/app/popup_files/style.css
@@ -1,6 +1,7 @@
 body {
   font-family: "Segoe UI", "Lucida Grande", Tahoma, sans-serif;
   font-size: 100%;
+  width: 25em;
 }
 
 #status {

--- a/manifest.json
+++ b/manifest.json
@@ -31,7 +31,9 @@
   "permissions": [
     "tabs",
     "alarms",
+    "notifications",
     "activeTab",
+    "storage",
     "http://127.0.0.1:5600/api/*",
     "http://127.0.0.1:5666/api/*"
   ]


### PR DESCRIPTION
- Added banner to the top of the popup
- Added field in popup to display if in testing mode
- Popup now shows when the last sync was performed
- Debug info is now in a <detail> tag
- Now uses the testing port (5666) when running in unpacked mode (fixes https://github.com/ActivityWatch/aw-watcher-web/issues/5)
- Now shows popup if failed to send heartbeat to the server