### PR TITLE
Running cheackmark is red when lastSyncSuccess is false, either it is green.

### DIFF
--- a/app/client.js
+++ b/app/client.js
@@ -96,6 +96,7 @@ var client = {
           client.lastSyncSuccess = true;
           chrome.storage.local.set({"lastSync": new Date().toISOString()});
         }
+        chrome.storage.local.set({"lastSyncSuccess": client.lastSyncSuccess});
       }
     };
     var payload = JSON.stringify({"data": data, "timestamp": timestamp.toISOString()});

--- a/app/popup_files/popup.js
+++ b/app/popup_files/popup.js
@@ -20,11 +20,12 @@ function getCurrentTabs(callback) {
 }
 
 function renderStatus() {
-  chrome.storage.local.get(["lastSync", "testing"], function(obj) {
+  chrome.storage.local.get(["lastSync", "lastSyncSuccess", "testing"], function(obj) {
     let lastSyncString = obj.lastSync ? new Date(obj.lastSync).toLocaleString() : "never";
+    let runningStatusColor = obj.lastSyncSuccess ? "#00AA00" : "#ff0000";
     var msg = "<table>";
     msg += "<tr>" +
-      "<th>Running:</th>" + "<td style='color: #00AA00; font-size: 1.5em;'>✔</td>" +
+      "<th>Running:</th>" + "<td style='color: " + runningStatusColor + "; font-size: 1.5em;'>✔</td>" +
     "</tr>";
     if(obj.testing == true) {
       msg += "<tr>" +


### PR DESCRIPTION
Tested on Chrome 62 and Firefox 57. It fixes https://github.com/ActivityWatch/aw-watcher-web/issues/12