### PR TITLE
Notification when connection successfully established after faile

### DIFF
--- a/app/client.js
+++ b/app/client.js
@@ -93,6 +93,14 @@ var client = {
           }
         } else {
           // SUCCESS
+          if(!client.lastSyncSuccess){
+            chrome.notifications.create({
+              "type": "basic",
+              "iconUrl": chrome.extension.getURL("media/logo/logo.png"),
+              "title": "Now connected again",
+              "message": "Now ActivityWatch server works at: " + client._getHost(),
+            });
+          }
           client.lastSyncSuccess = true;
           chrome.storage.local.set({"lastSync": new Date().toISOString()});
         }


### PR DESCRIPTION
Display notification with `Now connected again` message when connection to server is established with success and lastSyncSuccess is false.

Tested on Chrome 62 and Firefox 57.

https://github.com/ActivityWatch/aw-watcher-web/issues/13