### PR TITLE
Prevent heartbeat from sending while in incognito mode

### DIFF
--- a/app/eventPage.js
+++ b/app/eventPage.js
@@ -36,6 +36,10 @@ var last_heartbeat_data = null;
 var last_heartbeat_time = null;
 
 function heartbeat(tab) {
+  if (tab.incognito === true) {
+    return;
+  }
+  
   //console.log(JSON.stringify(tab));
   var now = new Date();
   var data = {"url": tab.url, "title": tab.title, "audible": tab.audible, "incognito": tab.incognito};

--- a/app/eventPage.js
+++ b/app/eventPage.js
@@ -36,6 +36,7 @@ var last_heartbeat_data = null;
 var last_heartbeat_time = null;
 
 function heartbeat(tab) {
+  // Prevent from sending in incognito mode (needed for firefox) - See https://github.com/ActivityWatch/aw-watcher-web/pull/18
   if (tab.incognito === true) {
     return;
   }


### PR DESCRIPTION
I really don't like that by default the extension sends heartbeats in incognito. Because in my opinion that's exactly what private browsing is for: to stop recording browsing history.

Therefore I'd like to make this a default (and maybe add an option to activate it in private browsing).


- [x] Tested in Firefox 60.0.1 on Ubuntu
- [ ] Tested in Chrome