### PR TITLE
Added permanent ID for Firefox

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -16,7 +16,8 @@
 
   "applications": {
     "gecko": {
-      "strict_min_version": "48.0"
+      "strict_min_version": "48.0",
+      "id": "{6b1794a0-5ae6-4443-aef9-7755717bb180}"
     }
   },
 


### PR DESCRIPTION
Should fix https://github.com/ActivityWatch/aw-server-rust/pull/47 in a more secure manner.

The only issue is that it now prevents you from running both development and production versions of aw-watcher-web in the same Firefox instance. But that can easily be achieved by temporarily setting the ID to something else.