### PR TITLE
Decide browsername from ua-parser library

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
     "dependencies": {
-        "browserify": "^16.2.3"
+        "browserify": "^16.2.3",
+        "ua-parser-js": "^0.7.20"
     },
     "scripts": {
         "build": "mkdir -p out; browserify src/*.js > out/app.js"

--- a/src/client.js
+++ b/src/client.js
@@ -1,6 +1,7 @@
 "use strict";
 
 var AWClient = require("../aw-client-js/out/aw-client.js").AWClient;
+var ua_parser = require('ua-parser-js');
 
 function emitNotification(title, message) {
   chrome.notifications.create({
@@ -31,9 +32,15 @@ var client = {
     });
   },
 
+  getBrowserName: function() {
+    var agent_parsed = ua_parser(navigator.userAgent);
+    var browsername = agent_parsed.browser.name;
+    return browsername.toLowerCase();
+  },
+
   getBucketId: function() {
     // TODO: This works for Chrome and Firefox, but is a bit hacky and wont work in the general case
-    var browserName = /(Chrome|Firefox)\/([0-9.]+)/.exec(navigator.userAgent)[1];
+    var browserName = client.getBrowserName();
     return "aw-watcher-web-" + browserName.toLowerCase();
   },
 


### PR DESCRIPTION
Tested with firefox, chrome and opera.
If someone uses chromium though the data for them will now move to a "aw-watcher-web-chromium" instead in theory, but I have not tested it.

Fixes #29 

Thanks  @kabili207  for the tip to use ua-parser!