### PR TITLE
Retry http requests before sending error notifications

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3,6 +3,11 @@
     "requires": true,
     "lockfileVersion": 1,
     "dependencies": {
+        "@types/retry": {
+            "version": "0.12.0",
+            "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.0.tgz",
+            "integrity": "sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA=="
+        },
         "JSONStream": {
             "version": "1.3.5",
             "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.5.tgz",
@@ -742,6 +747,15 @@
             "resolved": "https://registry.npmjs.org/os-browserify/-/os-browserify-0.3.0.tgz",
             "integrity": "sha1-hUNzx/XCMVkU/Jv8a9gjj92h7Cc="
         },
+        "p-retry": {
+            "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-4.2.0.tgz",
+            "integrity": "sha512-jPH38/MRh263KKcq0wBNOGFJbm+U6784RilTmHjB/HM9kH9V8WlCpVUcdOmip9cjXOh6MxZ5yk1z2SjDUJfWmA==",
+            "requires": {
+                "@types/retry": "^0.12.0",
+                "retry": "^0.12.0"
+            }
+        },
         "pako": {
             "version": "1.0.10",
             "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.10.tgz",
@@ -899,6 +913,11 @@
             "requires": {
                 "path-parse": "^1.0.6"
             }
+        },
+        "retry": {
+            "version": "0.12.0",
+            "resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
+            "integrity": "sha1-G0KmJmoh8HQh0bC1S33BZ7AcATs="
         },
         "ripemd160": {
             "version": "2.0.2",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     },
     "dependencies": {
         "browserify": "^16.2.3",
-        "ua-parser-js": "^0.7.20"
+        "ua-parser-js": "^0.7.20",
+        "p-retry": "^4.2.0"
     },
     "scripts": {
         "build": "mkdir -p out; browserify src/*.js > out/app.js"

--- a/src/client.js
+++ b/src/client.js
@@ -13,6 +13,15 @@ function emitNotification(title, message) {
   });
 }
 
+function logHttpError(error) {
+  // No response property for network errors
+  if (error.response) {
+    console.error("Status code: " + err.response.status + ", response: " + err.response.data.message);
+  } else {
+    console.error("Unexpected error: " + error);
+  }
+}
+
 var client = {
   testing: null,
   awc: null,
@@ -64,7 +73,8 @@ var client = {
     function attempt() {
       return client.awc.ensureBucket(bucket_id, eventtype, hostname)
         .catch( (err) => {
-          console.error("Failed to create bucket ("+err.response.status+"): "+err.response.data.message);
+          console.error("Failed to create bucket, retrying...");
+          logHttpError(err);
           return Promise.reject(err);
         }
       );
@@ -103,10 +113,10 @@ var client = {
             "Unable to send event to server",
             "Please ensure that ActivityWatch is running"
           );
-          client.lastSyncSuccess = false;
-          client.updateSyncStatus();
         }
-        console.error("Status code: " + err.response.status + ", response: " + err.response.data.message);
+        client.lastSyncSuccess = false;
+        client.updateSyncStatus();
+        logHttpError(err);
       }
     );
   }

--- a/src/client.js
+++ b/src/client.js
@@ -97,7 +97,7 @@ var client = {
       return this.awc.heartbeat(this.getBucketId(), pulsetime, payload);
     }
 
-    retry(attempt, { retries: 5 }).then(
+    retry(attempt, { retries: 3 }).then(
       (res) => {
         if (!client.lastSyncSuccess) {
           emitNotification(


### PR DESCRIPTION
Closes #41 

cc @ErikBjare 

Retry `AWClient.heartbeat` for five times (around half minute) before actually setting sync status to failed, and thus sending user error notification. `AWClient.ensureBucket` is retried forever because this method is called only once during startup. 

p-retry library uses cumulative backoff between retries.

Another idea was to use axios-retry library for automatic retry system, but implicit retry for POST requests might be a bit error prone.

You see something to improve before merging?