### PR TITLE
#35 Reenable ability to log incognito tabs

### DIFF
--- a/src/eventPage.js
+++ b/src/eventPage.js
@@ -37,11 +37,6 @@ var last_heartbeat_data = null;
 var last_heartbeat_time = null;
 
 function heartbeat(tab, tabCount) {
-  // Prevent from sending in incognito mode (needed for firefox) - See https://github.com/ActivityWatch/aw-watcher-web/pull/18
-  if (tab.incognito === true) {
-    return;
-  }
-
   //console.log(JSON.stringify(tab));
   var now = new Date();
   var data = {"url": tab.url, "title": tab.title, "audible": tab.audible, "incognito": tab.incognito, "tabCount": tabCount};


### PR DESCRIPTION
In Issue #35 you discussed re-enabling the logging of incognito tabs.
The consensus was, that the incognito logging could be re-enabled, but somehow nobody made a pull-request. So here we go!

Btw. I think it's really inconsistent that the web-watcher won't log pages in incognito mode since the window-watcher will log them anyway!