### PR TITLE
feat: Add custom browser name option

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 aw-watcher-web.zip
 out
 node_modules
+.DS_Store

--- a/src/client.js
+++ b/src/client.js
@@ -26,6 +26,9 @@ var client = {
   testing: null,
   awc: null,
   lastSyncSuccess: true,
+  config: {
+    browserNameOverride: ""
+  },
 
   setup: function() {
     console.log("Setting up client");
@@ -43,6 +46,7 @@ var client = {
   },
 
   getBrowserName: function() {
+    if (this.config.browserNameOverride) { return this.config.browserNameOverride; }
     var agent_parsed = ua_parser(navigator.userAgent);
     var browsername = agent_parsed.browser.name;
     return browsername.toLowerCase();

--- a/src/eventPage.js
+++ b/src/eventPage.js
@@ -146,13 +146,30 @@ function popupRequestReceived(msg) {
       stopWatcher();
     }
   }
+  else if (msg.config != undefined) {
+    let createBucket = false;
+    if (msg.config.browserNameOverride && msg.config.browserNameOverride != client.getBrowserName()) {
+      createBucket = true;
+    }
+    chrome.storage.local.set({ "config": msg.config });
+    client.config = msg.config;
+    if (createBucket) {
+      client.createBucket();
+    }
+  }
 }
 
 function startPopupListener() {
-  chrome.storage.local.get(["enabled"], function(obj) {
+  chrome.storage.local.get(["enabled", "config"], function (obj) {
     if (obj.enabled == undefined) {
       chrome.storage.local.set({"enabled": true});
     }
+    if (obj.config) {
+      client.config = obj.config;
+    }
+
+    // Don't start watcher until cache is loaded
+    startWatcher();
   });
   chrome.runtime.onMessage.addListener(popupRequestReceived);
 }
@@ -163,5 +180,4 @@ function startPopupListener() {
 
 (function() {
   startPopupListener();
-  startWatcher();
 })();

--- a/static/popup.html
+++ b/static/popup.html
@@ -56,7 +56,9 @@
     </tr>
   </table>
 
-  <button type="button" id="advanced-config-visible-toggle">Show/Hide Advanced Config</button>
+  <hr>
+
+  <button class="button" id="advanced-config-visible-toggle"><b>Show Advanced Config</b></button>
 
   <table id="advanced-config-table" style="visibility: hidden;">
     <tr>

--- a/static/popup.html
+++ b/static/popup.html
@@ -36,7 +36,7 @@
       <th align="right">Enabled:</th>
       <td>
         <input type="checkbox" id="status-enabled-checkbox">
-          <!-- Filled by JS -->
+        <!-- Filled by JS -->
         </input>
       </td>
     </tr>
@@ -52,6 +52,25 @@
       <th>Last sync:</th>
       <td id="status-last-sync">
         <!-- Filled by JS -->
+      </td>
+    </tr>
+  </table>
+
+  <button type="button" id="advanced-config-visible-toggle">Show/Hide Advanced Config</button>
+
+  <table id="advanced-config-table" style="visibility: hidden;">
+    <tr>
+      <th align="right">Browser:</th>
+      <td>
+        <select id="config-browser-name">
+          <option value="">Default</option>
+          <option value="chrome">Chrome</option>
+          <option value="firefox">Firefox</option>
+          <option value="opera">Opera</option>
+          <option value="brave">Brave</option>
+          <option value="edge">Edge</option>
+          <option value="vivaldi">Vivaldi</option>
+        </select>
       </td>
     </tr>
   </table>

--- a/static/popup.js
+++ b/static/popup.js
@@ -50,7 +50,10 @@ function domListeners() {
   let advanced_config_visible_toggle = document.getElementById('advanced-config-visible-toggle');
   advanced_config_visible_toggle.addEventListener("click", (obj) => {
     let visible = advanced_config_table.style.visibility == "visible";
-    advanced_config_table.style.visibility = visible ? "hidden" : "visible";
+    if (!visible) {
+      advanced_config_table.style.visibility = "visible";
+      obj.target.disabled = true;
+    }
   });
 
   let config_browser_name_select = document.getElementById('config-browser-name');

--- a/static/popup.js
+++ b/static/popup.js
@@ -1,5 +1,8 @@
 "use strict";
 
+// In-page cache of the user's config
+const config = {};
+
 function renderStatus() {
   chrome.storage.local.get(["lastSync", "lastSyncSuccess", "testing", "baseURL", "enabled"], function(obj) {
     // Enabled checkbox
@@ -28,16 +31,39 @@ function renderStatus() {
   });
 }
 
+function renderConfig() {
+  chrome.storage.local.get(["config"], function (obj) {
+    Object.assign(config, obj.config);
+    // Browser Name Dropdown
+    document.getElementById('config-browser-name').value = config.browserNameOverride;
+  });
+}
+
 function domListeners() {
   let enabled_checkbox = document.getElementById('status-enabled-checkbox');
   enabled_checkbox.addEventListener("change", (obj) => {
-    let enabled = obj.srcElement.checked;
+    let enabled = obj.target.checked;
     chrome.runtime.sendMessage({enabled: enabled}, function(response) {});
   });
+
+  let advanced_config_table = document.getElementById('advanced-config-table');
+  let advanced_config_visible_toggle = document.getElementById('advanced-config-visible-toggle');
+  advanced_config_visible_toggle.addEventListener("click", (obj) => {
+    let visible = advanced_config_table.style.visibility == "visible";
+    advanced_config_table.style.visibility = visible ? "hidden" : "visible";
+  });
+
+  let config_browser_name_select = document.getElementById('config-browser-name');
+  config_browser_name_select.addEventListener("change", (obj) => {
+    let browserName = obj.target.value;
+    config.browserNameOverride = browserName;
+    chrome.runtime.sendMessage({ config: config }, function (response) { });
+  })
 }
 
 document.addEventListener('DOMContentLoaded', function() {
   renderStatus();
+  renderConfig();
   domListeners();
 })
 

--- a/static/style.css
+++ b/static/style.css
@@ -20,6 +20,14 @@ a {
   border-radius: 0.2em;
   background-color: #EEE;
   border: 1px solid #DDD;
+  cursor: pointer;
+}
+
+.button:disabled {
+  display: inline-block;
+  color: #333333;
+  background-color: #DDD;
+  cursor: default;
 }
 
 #status {


### PR DESCRIPTION
The idea here was to add an option to override the browser name that is found in the user agent. This is because browsers such as Brave intentionally disguise themselves as Chrome and this causes issues that prevent the Browser tab in the web-ui from working correctly. 

See:
https://github.com/ActivityWatch/activitywatch/issues/461

This should resolve that issue without having to maintain custom code to get the correct browser name. This alone will not automatically work because of a previous work-around that was made, but will require that https://github.com/ActivityWatch/aw-webui/pull/283 also be merged so that everything is correctly mapped.