### PR TITLE
getBrowserName performance improvement

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,8 +10,7 @@
     },
     "dependencies": {
         "browserify": "^16.5.2",
-        "p-retry": "^4.4.0",
-        "ua-parser-js": "^0.7.24"
+        "p-retry": "^4.4.0"
     },
     "scripts": {
         "build": "mkdir -p out; browserify src/*.js > out/app.js"

--- a/src/client.js
+++ b/src/client.js
@@ -42,21 +42,22 @@ var client = {
   },
 
   getBrowserName: function () {
-    if (
-      navigator.userAgent.includes("Opera")||
-      navigator.userAgent.includes("OPR")
-    ) {
-      return "opera";
-    } else if (navigator.userAgent.includes("Firefox")) {
-      return "firefox";
-    } else if (navigator.userAgent.includes("Brave")) {
-      return "brave";
-    } else if (navigator.userAgent.includes("Chrome")) {
-      return "chrome";
-    } else if (navigator.userAgent.includes("Safari")) {
-      return "safari";
-    } else {
-      return "unknown";
+    switch (true) {
+      case navigator.userAgent.includes("Firefox"):
+        return "firefox"
+      case navigator.userAgent.includes("Brave"):
+        return "brave"
+      case navigator.userAgent.includes("Edg"):
+        return "edge"
+      case navigator.userAgent.includes("Opera"):
+      case navigator.userAgent.includes("OPR"):
+        return "opera"
+      case navigator.userAgent.includes("Chrome"):
+        return "chrome"
+      case navigator.userAgent.includes("Safari"):
+        return "safari"
+      default:
+        return "unknown"
     }
   },
 

--- a/src/client.js
+++ b/src/client.js
@@ -1,7 +1,6 @@
 "use strict";
 
 var AWClient = require("../aw-client-js/out/aw-client.js").AWClient;
-var ua_parser = require("ua-parser-js");
 var retry = require("p-retry") // See aw-watcher-web issue #41
 
 function emitNotification(title, message) {
@@ -42,10 +41,21 @@ var client = {
     });
   },
 
-  getBrowserName: function() {
-    var agent_parsed = ua_parser(navigator.userAgent);
-    var browsername = agent_parsed.browser.name;
-    return browsername.toLowerCase();
+  getBrowserName: function () {
+    if (
+      navigator.userAgent.indexOf("Opera") != -1 ||
+      navigator.userAgent.indexOf("OPR") != -1
+    ) {
+      return "opera";
+    } else if (navigator.userAgent.indexOf("Firefox") != -1) {
+      return "firefox";
+    } else if (navigator.userAgent.indexOf("Chrome") != -1) {
+      return "chrome";
+    } else if (navigator.userAgent.indexOf("Safari") != -1) {
+      return "safari";
+    } else {
+      return "unknown";
+    }
   },
 
   getBucketId: function() {

--- a/src/client.js
+++ b/src/client.js
@@ -43,15 +43,17 @@ var client = {
 
   getBrowserName: function () {
     if (
-      navigator.userAgent.indexOf("Opera") != -1 ||
-      navigator.userAgent.indexOf("OPR") != -1
+      navigator.userAgent.includes("Opera")||
+      navigator.userAgent.includes("OPR")
     ) {
       return "opera";
-    } else if (navigator.userAgent.indexOf("Firefox") != -1) {
+    } else if (navigator.userAgent.includes("Firefox")) {
       return "firefox";
-    } else if (navigator.userAgent.indexOf("Chrome") != -1) {
+    } else if (navigator.userAgent.includes("Brave")) {
+      return "brave";
+    } else if (navigator.userAgent.includes("Chrome")) {
       return "chrome";
-    } else if (navigator.userAgent.indexOf("Safari") != -1) {
+    } else if (navigator.userAgent.includes("Safari")) {
       return "safari";
     } else {
       return "unknown";


### PR DESCRIPTION
Performance improvement on the getBrowserName function.

1. app.js file size goes from 115.8KB -> 73.5KB
2. Using String.prototype.includes() instead of Regex
3. Avoid .exec() on many regexes (From ua-parser-js dependency)

Negative impact being that aw-watcher-web will not detect more rarely used browsers. This might be justified due to the application only being on the Firefox and Chrome addon store and the ease of adding support for a missing browser. The browser name "unknown" is used in the case of an unsupported browser.

I tested this on Firefox only.