### PR TITLE
Feature: Privacy Notice Consent popup for Firefox

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,22 @@ Install for your browser:
 [last-xpi]: https://github.com/ActivityWatch/aw-watcher-web/releases/download/v0.4.3/aw-watcher-web-v0.4.3.xpi
 [818]: https://github.com/orgs/ActivityWatch/discussions/818#discussioncomment-4017528
 
+### Firefox Enterprise Policy
+
+Due to the issue mentioned above, a privacy notice as to be displayed to follow the mozilla add-on policy. This can be pre-accepted by setting the following Firefox Enterprise Policy:
+```json
+{
+  "policies": {
+    "3rdparty": {
+      "Extensions": {
+        "{ef87d84c-2127-493f-b952-5b4e744245bc}": {
+          "consentOfflineDataCollection": true
+        }
+      }
+    }
+  }
+}
+```
 
 ## Building
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Install for your browser:
 
 ### Firefox Enterprise Policy
 
-Due to the issue mentioned above, a privacy notice as to be displayed to follow the mozilla add-on policy. This can be pre-accepted by setting the following Firefox Enterprise Policy:
+Due to the issue mentioned above, a privacy notice has to be displayed to follow the Mozilla add-on policy. This can be pre-accepted by setting the following Firefox Enterprise Policy:
 ```json
 {
   "policies": {

--- a/manifest.json
+++ b/manifest.json
@@ -22,6 +22,7 @@
 
   "background": {
     "scripts": [
+        "static/installed.js",
         "out/app.js"
     ],
     "persistent": false

--- a/src/eventPage.js
+++ b/src/eventPage.js
@@ -162,6 +162,14 @@ async function askConsentNeeded() {
   if (browserInfo.name != "Firefox") {
     return false
   }
+  try {
+    if (await browser.storage.managed.get("consentOfflineDataCollection")) {
+      return false
+    }
+  } catch (e) {
+    console.error('managed storage error: ', e)
+    return true
+  }
   return true
 }
 

--- a/src/eventPage.js
+++ b/src/eventPage.js
@@ -148,10 +148,44 @@ function popupRequestReceived(msg) {
   }
 }
 
+async function askConsentNeeded() {
+  // Source for compatibility check: https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/Build_a_cross_browser_extension#handling_api_differences
+  if (typeof browser.runtime.getBrowserInfo != "function") {
+    return false
+  }
+  let browserInfo;
+  await browser.runtime.getBrowserInfo().then((info) => {browserInfo = info})
+  if (browserInfo.name != "Firefox") {
+    return false
+  }
+  return true
+}
+
+function requestConsent() {
+  // Modified from Source: https://extensionworkshop.com/documentation/develop/onboard-upboard-offboard-users/#onboarding
+  browser.runtime.onInstalled.addListener(async ({ reason, temporary }) => {
+    // if (temporary) return; // skip during development
+    switch (reason) {
+      case "install":
+        {
+          const url = browser.runtime.getURL("../static/consent.html");
+          browser.windows.create({ url, type: "popup", height: 420, width: 416, });
+        }
+        break;
+    }
+  });
+}
+
 function startPopupListener() {
   chrome.storage.local.get(["enabled"], function(obj) {
     if (obj.enabled == undefined) {
-      chrome.storage.local.set({"enabled": true});
+      if(askConsentNeeded()) {
+        chrome.storage.local.set({"enabled": false}); // TODO: replace with storage.managed
+        requestConsent();
+      } else {
+        chrome.storage.local.set({"enabled": true});
+        startWatcher();
+      }
     }
   });
   chrome.runtime.onMessage.addListener(popupRequestReceived);
@@ -163,5 +197,5 @@ function startPopupListener() {
 
 (function() {
   startPopupListener();
-  startWatcher();
+  // startWatcher() moved to startPopupListener
 })();

--- a/static/consent.html
+++ b/static/consent.html
@@ -19,7 +19,7 @@
     This extension by nature collects personal identifiable information in the form of URLs. All collected information never leaves your device because all data is only forwarded to localhost. Since this is the core functionality of this extension, the only option to not consent, is to uninstall.
   </p>
   <div class="action-container">
-    <div class="action"><button class="button" id="consent-refused">Close Window</button></div>
+    <div class="action"><button class="button" id="consent-refused">Remove ActivityWatch</button></div>
     <div class="action"><button class="button accept" id="consent-given">Consent to offline data collection</button></div>
   </div>
 

--- a/static/consent.html
+++ b/static/consent.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+  <title>ActivityWatch Consent Dialog</title>
+
+  <link href="./style.css" rel="stylesheet" type="text/css">
+
+  <script src="./consent.js"></script>
+</head>
+
+<body class="consent">
+  <img src="/media/banners/banner.png" style="width: 100%">
+
+  <hr>
+
+  <h1>Privacy Notice</h1>
+  <p>
+    This extension by nature collects personal identifiable information in the form of URLs. All collected information never leaves your device because all data is only forwarded to localhost. Since this is the core functionality of this extension, the only option to not consent, is to uninstall.
+  </p>
+  <div class="action-container">
+    <div class="action"><button class="button" id="consent-refused">Remove ActivityWatch</button></div>
+    <div class="action"><button class="button accept" id="consent-given">Consent to offline data collection</button></div>
+  </div>
+
+</body>
+
+</html>

--- a/static/consent.html
+++ b/static/consent.html
@@ -19,7 +19,7 @@
     This extension by nature collects personal identifiable information in the form of URLs. All collected information never leaves your device because all data is only forwarded to localhost. Since this is the core functionality of this extension, the only option to not consent, is to uninstall.
   </p>
   <div class="action-container">
-    <div class="action"><button class="button" id="consent-refused">Remove ActivityWatch</button></div>
+    <div class="action"><button class="button" id="consent-refused">Close Window</button></div>
     <div class="action"><button class="button accept" id="consent-given">Consent to offline data collection</button></div>
   </div>
 

--- a/static/consent.js
+++ b/static/consent.js
@@ -4,6 +4,7 @@ function consentListeners() {
   let consent_refused = document.getElementById('consent-refused');
   let consent_given = document.getElementById('consent-given');
   consent_refused.addEventListener("click", (obj) => {
+    browser.management.uninstallSelf()
     window.close()
   });
   consent_given.addEventListener("click", (obj) => {

--- a/static/consent.js
+++ b/static/consent.js
@@ -4,11 +4,12 @@ function consentListeners() {
   let consent_refused = document.getElementById('consent-refused');
   let consent_given = document.getElementById('consent-given');
   consent_refused.addEventListener("click", (obj) => {
-    // TODO: close popup
+    window.close()
   });
   consent_given.addEventListener("click", (obj) => {
     chrome.runtime.sendMessage({enabled: true}, function(response) {});
-    // TODO: Dismiss Popup
+    chrome.storage.local.set({"noConsentGiven": false});
+    window.close()
   })
 }
 

--- a/static/consent.js
+++ b/static/consent.js
@@ -4,8 +4,7 @@ function consentListeners() {
   let consent_refused = document.getElementById('consent-refused');
   let consent_given = document.getElementById('consent-given');
   consent_refused.addEventListener("click", (obj) => {
-    // Source: https://stackoverflow.com/questions/39154543/can-a-firefox-extension-uninstall-itself
-    // TODO: Uninstall Extension
+    // TODO: close popup
   });
   consent_given.addEventListener("click", (obj) => {
     chrome.runtime.sendMessage({enabled: true}, function(response) {});

--- a/static/consent.js
+++ b/static/consent.js
@@ -1,0 +1,18 @@
+"use strict";
+
+function consentListeners() {
+  let consent_refused = document.getElementById('consent-refused');
+  let consent_given = document.getElementById('consent-given');
+  consent_refused.addEventListener("click", (obj) => {
+    // Source: https://stackoverflow.com/questions/39154543/can-a-firefox-extension-uninstall-itself
+    // TODO: Uninstall Extension
+  });
+  consent_given.addEventListener("click", (obj) => {
+    chrome.runtime.sendMessage({enabled: true}, function(response) {});
+    // TODO: Dismiss Popup
+  })
+}
+
+document.addEventListener('DOMContentLoaded', function() {
+  consentListeners();
+})

--- a/static/installed.js
+++ b/static/installed.js
@@ -1,7 +1,6 @@
 "use strict";
 
 chrome.runtime.onInstalled.addListener(async ({ reason, temporary }) => {
-  // if (temporary) return; // skip during development
   switch (reason) {
     case "install":
       {

--- a/static/installed.js
+++ b/static/installed.js
@@ -1,0 +1,12 @@
+"use strict";
+
+chrome.runtime.onInstalled.addListener(async ({ reason, temporary }) => {
+  // if (temporary) return; // skip during development
+  switch (reason) {
+    case "install":
+      {
+        chrome.storage.local.set({"askConsent": true});
+      }
+      break;
+  }
+});

--- a/static/popup.html
+++ b/static/popup.html
@@ -39,6 +39,9 @@
           <!-- Filled by JS -->
         </input>
       </td>
+      <td>
+        <button id="status-consent-btn">Consent to Privacy Notice</button>
+      </td>
     </tr>
 
     <tr>

--- a/static/popup.js
+++ b/static/popup.js
@@ -17,7 +17,7 @@ function renderStatus() {
         enabledCheckbox.removeAttribute('disabled');
         showConsentBtn.style.display = 'none';
       }
-    })
+    });
 
     // Connected
     let connectedColor = obj.lastSyncSuccess ? "#00AA00" : "#FF0000";

--- a/static/popup.js
+++ b/static/popup.js
@@ -1,9 +1,23 @@
 "use strict";
 
 function renderStatus() {
-  chrome.storage.local.get(["lastSync", "lastSyncSuccess", "testing", "baseURL", "enabled"], function(obj) {
+  chrome.storage.local.get(["lastSync", "lastSyncSuccess", "testing", "baseURL", "enabled"], async function(obj) {
     // Enabled checkbox
-    document.getElementById('status-enabled-checkbox').checked = obj.enabled;
+    let enabledCheckbox = document.getElementById('status-enabled-checkbox');
+    enabledCheckbox.checked = obj.enabled;
+
+    // Consent Button
+    let showConsentBtn = document.getElementById('status-consent-btn');
+    chrome.storage.local.get("noConsentGiven", (obj) => {
+      console.log('noConsentGiven: ', obj.noConsentGiven)
+      if (obj.noConsentGiven) {
+        enabledCheckbox.setAttribute('disabled', '');
+        showConsentBtn.style.display = 'inline-block';
+      } else {
+        enabledCheckbox.removeAttribute('disabled');
+        showConsentBtn.style.display = 'none';
+      }
+    })
 
     // Connected
     let connectedColor = obj.lastSyncSuccess ? "#00AA00" : "#FF0000";
@@ -33,6 +47,11 @@ function domListeners() {
   enabled_checkbox.addEventListener("change", (obj) => {
     let enabled = obj.srcElement.checked;
     chrome.runtime.sendMessage({enabled: enabled}, function(response) {});
+  });
+  let consent_button = document.getElementById('status-consent-btn');
+  consent_button.addEventListener('click', () => {
+    const url = chrome.runtime.getURL("../static/consent.html");
+    chrome.windows.create({ url, type: "popup", height: 420, width: 416, });
   });
 }
 

--- a/static/popup.js
+++ b/static/popup.js
@@ -1,7 +1,7 @@
 "use strict";
 
 function renderStatus() {
-  chrome.storage.local.get(["lastSync", "lastSyncSuccess", "testing", "baseURL", "enabled"], async function(obj) {
+  chrome.storage.local.get(["lastSync", "lastSyncSuccess", "testing", "baseURL", "enabled"], function(obj) {
     // Enabled checkbox
     let enabledCheckbox = document.getElementById('status-enabled-checkbox');
     enabledCheckbox.checked = obj.enabled;

--- a/static/style.css
+++ b/static/style.css
@@ -35,6 +35,10 @@ button {
   border: 1px solid #DDD;
 }
 
+#status-consent-btn {
+  display: none;
+}
+
 .accept {
   color: #FFF;
   background-color: #007ef8;

--- a/static/style.css
+++ b/static/style.css
@@ -4,12 +4,25 @@ body {
   width: 25em;
 }
 
+.consent {
+  width: 400px;
+}
+
 hr {
   border: 1px solid #DDD;
 }
 
 a {
   text-decoration: none;
+}
+
+h1 {
+  margin-bottom: 0px;
+}
+
+button {
+  cursor: pointer;
+  font-size: 100%;
 }
 
 .button {
@@ -22,6 +35,12 @@ a {
   border: 1px solid #DDD;
 }
 
+.accept {
+  color: #FFF;
+  background-color: #007ef8;
+  border: 1px solid #0073e6;
+}
+
 #status {
   /* avoid an excessively wide status text */
   white-space: pre;
@@ -29,3 +48,11 @@ a {
   overflow: hidden;
   max-width: 400px;
 }
+
+.action-container {
+  display: flex;
+}
+
+/* .action {
+  flex: 1;
+} */


### PR DESCRIPTION
This pull request addresses the issue raised [here](https://github.com/orgs/ActivityWatch/discussions/818). This should satisfy the Mozilla addon review team. I have written a small Privacy Notice in `static/consent.html`, no idea if this is enough and if it can be used as a privacy policy for the whole addon...

I have added a saveguard to the normal addon popup page. If the user dismisses the privacy notice, the enable checkbox is disabled and a button is shown that shows the consent popup again.

I tested this with latest Firefox and Chromium.