### PR TITLE
fix: init on browser startup

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -25,7 +25,7 @@
         "static/installed.js",
         "out/app.js"
     ],
-    "persistent": false
+    "persistent": true
   },
 
   "permissions": [


### PR DESCRIPTION
Fixes #107 

Copy/Pasting my comment from #107:

The background script is not executed on browser startup because `persistent` is set to `false`.

https://github.com/ActivityWatch/aw-watcher-web/blob/b53d09997e97261e3246d1e225d12b4e4b85dd6f/manifest.json#L28

`persistent: true` is also the default behavior when unset. And I don't know of any extension that uses `persistent: false`.

---

For reference:

https://github.com/Cookie-AutoDelete/Cookie-AutoDelete/blob/ca628ccfa567eeb5e088c74812090659185132b2/extension/manifest.json#L2-L11
https://github.com/darkreader/darkreader/blob/6723337369f784468c28f1d757c46227255693aa/src/manifest.json#L22
https://github.com/darkreader/darkreader/blob/6723337369f784468c28f1d757c46227255693aa/src/manifest-firefox.json#L8-L10C2
https://github.com/ClearURLs/Addon/blob/14a0832973e137f0cbbbb1e9110c1286bc88e319/manifest.json#L57-L74
https://github.com/ajayyy/SponsorBlock/blob/b07381e5d0bae8cea21af7054f7a6464c889a6d4/manifest/manifest.json#L121-L125
https://github.com/gorhill/uBlock/blob/5ba3055bc77cf99ff20d5d29da53fc78b6b6e9e0/platform/firefox/manifest.json#L3-L5