### PR TITLE
Added caching to getBrowserName()

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -62,12 +62,12 @@ var client = {
     });
   },
 
-  createBucket: async function(){
+  createBucket: function(){
     if (this.testing === null)
       return;
     // TODO: We might want to get the hostname somehow, maybe like this:
     // https://stackoverflow.com/questions/28223087/how-can-i-allow-firefox-or-chrome-to-read-a-pcs-hostname-or-other-assignable
-    var bucket_id = await this.getBucketId();
+    var bucket_id = this.getBucketId();
     var eventtype = "web.tab.current";
     var hostname = "unknown";
 


### PR DESCRIPTION
This time (my second PR on this optimizing getBrowserName, previous: https://github.com/ActivityWatch/aw-watcher-web/pull/89) I went with a caching approach instead of writing a lightweight alternative to UAParser.

UAParser is still a fairly heavy library, however we will only be using it for the first time we call getBrowserName().

I have only tested in Firefox where it seems to work perfectly fine.

A few functions have been turned asynchronous, however I have not spotted any places where that could be an issue, and awaits have been added where needed.