### PR TITLE
fix: add a brave-specific check

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -23,6 +23,9 @@ function logHttpError(error) {
 }
 
 function getBrowserName() {
+  if (navigator.brave?.isBrave())
+    return "brave";
+
   // Get browser name from UAParser (somewhat expensive operation)
   var agent_parsed = ua_parser(navigator.userAgent);
   var browserName = agent_parsed.browser.name.toLowerCase();


### PR DESCRIPTION
Use the Brave specific API to check if the browser is Brave.
Manually tested, works on my machine :)

---

- Fixes https://github.com/ActivityWatch/activitywatch/issues/461

<!--
ELLIPSIS_HIDDEN
-->


----

| :rocket: This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 39bb78f04ce807271992ce02007b50f309ecfbbe  | 
|--------|

### Summary:
This PR optimizes browser detection by adding a Brave-specific check in the `getBrowserName` function of `src/client.js`, improving performance by avoiding unnecessary operations.

**Key points**:
- Adds Brave browser check using `navigator.brave?.isBrave()` in `getBrowserName` function in `src/client.js`.
- Returns 'brave' immediately if the browser is Brave, before using UAParser.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)



<!--
ELLIPSIS_HIDDEN
-->
