### PR TITLE
Allow manually configuring the hostname

### DIFF
--- a/static/popup.html
+++ b/static/popup.html
@@ -51,10 +51,20 @@
       </td>
     </tr>
 
-    <tr align="right">
-      <th>Last sync:</th>
+    <tr>
+      <th align="right">Last sync:</th>
       <td id="status-last-sync">
         <!-- Filled by JS -->
+      </td>
+    </tr>
+
+    <tr>
+      <th align="right">Hostname:</th>
+      <td>
+        <input id="hostname-textbox">
+          <!-- Filled by JS -->
+        </input>
+        <button id="hostname-save-button">Save</button>
       </td>
     </tr>
   </table>

--- a/static/popup.js
+++ b/static/popup.js
@@ -1,7 +1,7 @@
 "use strict";
 
 function renderStatus() {
-  chrome.storage.local.get(["lastSync", "lastSyncSuccess", "testing", "baseURL", "enabled"], function(obj) {
+  chrome.storage.local.get(["lastSync", "lastSyncSuccess", "testing", "baseURL", "enabled", "hostname"], function(obj) {
     // Enabled checkbox
     let enabledCheckbox = document.getElementById('status-enabled-checkbox');
     enabledCheckbox.checked = obj.enabled;
@@ -37,6 +37,10 @@ function renderStatus() {
     let lastSyncString = obj.lastSync ? new Date(obj.lastSync).toLocaleString() : "never";
     document.getElementById('status-last-sync').innerHTML = lastSyncString;
 
+    // Hostname
+    let hostnameTextbox = document.getElementById('hostname-textbox');
+    hostnameTextbox.value = obj.hostname || "";
+
     // Set webUI button link
     document.getElementById('webui-link').href = obj.baseURL;
   });
@@ -52,6 +56,17 @@ function domListeners() {
   consent_button.addEventListener('click', () => {
     const url = chrome.runtime.getURL("../static/consent.html");
     chrome.windows.create({ url, type: "popup", height: 550, width: 416, });
+  });
+  let hostnameTextbox = document.getElementById('hostname-textbox');
+  let hostnameSaveButton = document.getElementById('hostname-save-button');
+  hostnameSaveButton.addEventListener("click", () => {
+    chrome.storage.local.set({ hostname: hostnameTextbox.value });
+    // Need to restart the extension to update the bucket name
+    let enabled = enabled_checkbox.checked;
+    if (enabled) {
+      chrome.runtime.sendMessage({enabled: false});
+      chrome.runtime.sendMessage({enabled: true});
+    }
   });
 }
 


### PR DESCRIPTION
Without any obvious ability for the extension to determine the machine's hostname automatically, the best available option seems to be to allow users to configure it manually. A field is added to the extension popup to configure the hostname.

The field is blank by default, and the updates were designed to ensure that the behaviour if the hostname is not set will be unchanged (so people using workflows that expect browser data in the "unknown" host bucket won't see anything break; they can set the hostname once they're prepared to do so).

Fixes #132

<img src="https://github.com/user-attachments/assets/1e0b06ab-0238-4947-a789-93b1289ae720" width="444">

----

If anyone using Firefox wants to test this out, I've created a signed version of the extension from this PR: [aw-watcher-web-9462f488983245cbad32-0.4.8.9999.xpi](https://www.kepstin.ca/dump/aw-watcher-web-9462f488983245cbad32-0.4.8.9999.xpi). Please note that this extension is signed using my personal key and uses a different extension ID from the official ActivityWatch extension - as a result it will install alongside the official extension and will not share settings.

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds manual hostname configuration to the extension, allowing users to set a hostname via the popup UI, while maintaining default behavior if not set.
> 
>   - **Behavior**:
>     - Adds manual hostname configuration in `client.js` using a new input field in the popup.
>     - Defaults to previous behavior if hostname is not set, maintaining compatibility.
>   - **UI Changes**:
>     - Adds `Hostname` input field and `Save` button in `popup.html`.
>     - Updates `popup.js` to handle hostname input and save functionality.
>   - **Functions**:
>     - Modifies `setup()` and `getBucketId()` in `client.js` to incorporate hostname logic.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ActivityWatch%2Faw-watcher-web&utm_source=github&utm_medium=referral)<sup> for 53e1345efd7f6e66e822786637e74095aa1657ba. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->