### PR TITLE
Allow manually configuring the browser name

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -27,6 +27,10 @@
     "persistent": false
   },
 
+  "options_ui": {
+    "page": "static/options.html"
+  },
+
   "permissions": [
     "tabs",
     "alarms",

--- a/static/options.html
+++ b/static/options.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+    <meta charset="utf-8">
+    <title>ActivityWatch settings</title>
+    <link href="./style.css" rel="stylesheet" type="text/css">
+</head>
+
+<body>
+    <form>
+        <label for="browser">Browser:</label>
+        <!-- List based on https://github.com/ActivityWatch/aw-webui/blob/master/src/queries.ts#L216 -->
+        <select id="browser" name="browser">
+            <option value="chrome">Chrome</option>
+            <option value="firefox">Firefox</option>
+            <option value="opera">Opera</option>
+            <option value="brave">Brave</option>
+            <option value="edge">Edge</option>
+            <option value="arc">Arc</option>
+            <option value="vivaldi">Vivaldi</option>
+            <option value="orion">Orion</option>
+            <option value="yandex">Yandex</option>
+        </select>
+        <button type="submit" class="button accept">Save</button>
+    </form>
+    <script src="./options.js"></script>
+</body>
+
+</html>

--- a/static/options.js
+++ b/static/options.js
@@ -7,20 +7,19 @@ async function reloadExtension() {
 async function saveOptions(e) {
     e.preventDefault();
     const selectedBrowser = document.querySelector("#browser").value;
-    
-    await new Promise((resolve) => {
-        chrome.storage.local.set({
-            browserName: selectedBrowser
-        }, resolve);
-    });
 
     const button = e.target.querySelector("button");
     button.textContent = "Saving...";
     button.classList.remove('accept');
 
-    setTimeout(() => {
-        reloadExtension();
-    }, 500);
+    await new Promise((resolve) => {
+        chrome.storage.local.set({
+            browserName: selectedBrowser
+        }, () => {
+            reloadExtension();
+            resolve();
+        });
+    });
 }
 
 function restoreOptions() {

--- a/static/options.js
+++ b/static/options.js
@@ -7,8 +7,11 @@ async function reloadExtension() {
 async function saveOptions(e) {
     e.preventDefault();
     const selectedBrowser = document.querySelector("#browser").value;
-    await chrome.storage.local.set({
-        browserName: selectedBrowser
+    
+    await new Promise((resolve) => {
+        chrome.storage.local.set({
+            browserName: selectedBrowser
+        }, resolve);
     });
 
     const button = e.target.querySelector("button");

--- a/static/options.js
+++ b/static/options.js
@@ -1,0 +1,32 @@
+"use strict";
+
+async function reloadExtension() {
+    chrome.runtime.reload();
+}
+
+async function saveOptions(e) {
+    e.preventDefault();
+    const selectedBrowser = document.querySelector("#browser").value;
+    await chrome.storage.local.set({
+        browserName: selectedBrowser
+    });
+
+    const button = e.target.querySelector("button");
+    button.textContent = "Saving...";
+    button.classList.remove('accept');
+
+    setTimeout(() => {
+        reloadExtension();
+    }, 500);
+}
+
+function restoreOptions() {
+    chrome.storage.local.get("browserName", function (result) {
+        if (result.browserName) {
+            document.querySelector("#browser").value = result.browserName;
+        }
+    });
+}
+
+document.addEventListener("DOMContentLoaded", restoreOptions);
+document.querySelector("form").addEventListener("submit", saveOptions);

--- a/static/options.js
+++ b/static/options.js
@@ -10,7 +10,7 @@ async function saveOptions(e) {
 
     const button = e.target.querySelector("button");
     button.textContent = "Saving...";
-    button.classList.remove('accept');
+    button.classList.remove("accept");
 
     await new Promise((resolve) => {
         chrome.storage.local.set({

--- a/static/popup.html
+++ b/static/popup.html
@@ -57,6 +57,16 @@
         <!-- Filled by JS -->
       </td>
     </tr>
+
+    <tr>
+      <th align="right">Browser:</th>
+      <td>
+        <code id="status-browser">
+          <!-- Filled by JS -->
+        </code>
+        <button id="edit-btn">✎</button>
+      </td>
+    </tr>
   </table>
 
   <hr>

--- a/static/popup.js
+++ b/static/popup.js
@@ -1,7 +1,7 @@
 "use strict";
 
 function renderStatus() {
-  chrome.storage.local.get(["lastSync", "lastSyncSuccess", "testing", "baseURL", "enabled"], function(obj) {
+  chrome.storage.local.get(["lastSync", "lastSyncSuccess", "testing", "baseURL", "enabled", "browserName"], function(obj) {
     // Enabled checkbox
     let enabledCheckbox = document.getElementById('status-enabled-checkbox');
     enabledCheckbox.checked = obj.enabled;
@@ -37,6 +37,9 @@ function renderStatus() {
     let lastSyncString = obj.lastSync ? new Date(obj.lastSync).toLocaleString() : "never";
     document.getElementById('status-last-sync').innerHTML = lastSyncString;
 
+    // Browser name
+    document.getElementById("status-browser").innerText = obj.browserName;
+
     // Set webUI button link
     document.getElementById('webui-link').href = obj.baseURL;
   });
@@ -52,6 +55,10 @@ function domListeners() {
   consent_button.addEventListener('click', () => {
     const url = chrome.runtime.getURL("../static/consent.html");
     chrome.windows.create({ url, type: "popup", height: 550, width: 416, });
+  });
+  let browser_button = document.getElementById('edit-btn');
+  browser_button.addEventListener('click', () => {
+    chrome.runtime.openOptionsPage();
   });
 }
 

--- a/static/style.css
+++ b/static/style.css
@@ -60,3 +60,11 @@ button {
 /* .action {
   flex: 1;
 } */
+
+form {
+  margin: 0 0.5em;
+}
+
+label {
+  font-weight: bold;
+}


### PR DESCRIPTION
<img width="51%" alt="Screenshot 2025-02-04 at 01 22 24" src="https://github.com/user-attachments/assets/0a6ccba7-653d-41c1-a3bd-dc9541190591" />
<img width="47%" alt="Screenshot 2025-02-04 at 01 46 54" src="https://github.com/user-attachments/assets/7dec3925-c33e-45ec-b791-efd6ac7a5e58" />

---

- Fixes https://github.com/ActivityWatch/aw-watcher-web/issues/77
- Fixes https://github.com/ActivityWatch/aw-watcher-web/issues/88
- Fixes https://github.com/ActivityWatch/aw-watcher-web/issues/90
- Fixes https://github.com/ActivityWatch/aw-watcher-web/issues/91
- Fixes https://github.com/ActivityWatch/aw-watcher-web/issues/92
- Fixes https://github.com/ActivityWatch/aw-watcher-web/issues/118
- Fixes https://github.com/ActivityWatch/activitywatch/issues/774
- Fixes https://github.com/ActivityWatch/activitywatch/issues/942
- Fixes https://github.com/ActivityWatch/activitywatch/issues/1094
- Closes https://github.com/ActivityWatch/aw-webui/pull/622

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Adds manual browser name configuration to ActivityWatch extension with UI for selection and storage.
> 
>   - **Behavior**:
>     - Adds manual browser name configuration via `options.html` and `options.js`.
>     - `getBrowserName()` in `client.js` now checks `chrome.storage` for a manually set browser name.
>     - Updates `popup.html` and `popup.js` to display and edit the browser name.
>   - **UI**:
>     - New `options.html` for browser selection.
>     - Adds a dropdown in `options.html` for browser selection with options like Chrome, Firefox, etc.
>     - `popup.html` updated to include a button to open the options page.
>   - **Storage**:
>     - Saves selected browser name to `chrome.storage.local` in `options.js`.
>     - Retrieves and displays stored browser name in `popup.js` and `client.js`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ActivityWatch%2Faw-watcher-web&utm_source=github&utm_medium=referral)<sup> for e0759c626dac1681354d286295c02cc9838781b5. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->