### PR TITLE
ci: update actions to the latest versions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,11 +18,11 @@ jobs:
         node-version: [12.x]
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
       with:
         submodules: 'recursive'
     - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v1
+      uses: actions/setup-node@v4
       with:
         node-version: ${{ matrix.node-version }}
     - name: Install
@@ -30,7 +30,7 @@ jobs:
     - name: Build
       run: make build
     - name: Upload artifact
-      uses: actions/upload-artifact@v2-preview
+      uses: actions/upload-artifact@v4
       with:
         name: aw-watcher-web
         path: aw-watcher-web.zip

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -24,18 +24,18 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v2
+        uses: github/codeql-action/init@v3
         with:
           languages: ${{ matrix.language }}
           queries: +security-and-quality
 
       - name: Autobuild
-        uses: github/codeql-action/autobuild@v2
+        uses: github/codeql-action/autobuild@v3
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v2
+        uses: github/codeql-action/analyze@v3
         with:
           category: "/language:${{ matrix.language }}"


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Update GitHub Actions to latest versions in `build.yml` and `codeql.yml`.
> 
>   - **GitHub Actions Update**:
>     - Update `actions/checkout` to `v4` in both `build.yml` and `codeql.yml`.
>     - Update `actions/setup-node` to `v4` in `build.yml`.
>     - Update `actions/upload-artifact` to `v4` in `build.yml`.
>     - Update `github/codeql-action/init`, `autobuild`, and `analyze` to `v3` in `codeql.yml`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ActivityWatch%2Faw-watcher-web&utm_source=github&utm_medium=referral)<sup> for 95e055d3a8678f466ba0b95db3964455083f74e5. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->