### PR TITLE
Rewrite the Privacy Notice

### DIFF
--- a/static/consent.html
+++ b/static/consent.html
@@ -18,20 +18,20 @@
   <!-- This box border helps highlight that there is more text if the box is cut off by a small window -->
   <div style="text-overflow: scroll; border: 2px solid #DDD; border-radius: 2px; margin: 0.5em; padding: 0 0.5em 0 0.5em;">
     <p>
-      This extension collects information about the active tab, such as its title, URL, wether it is audible, or incognito/private.
+      This extension collects information about the active tab, such as its title, URL, whether it is audible, or incognito/private.
     </p>
 
     <p>
-      It stores that information in your locally installed ActivityWatch instance, which is required for the functioning of this extension.
-      It is never sent elsewhere than to the local device.
+      It stores this information in your locally installed ActivityWatch instance, which is required for this extension to work.
+      It is never sent anywhere other than to the local device.
     </p>
 
     <p>
-      Due to Mozilla policy, we need to ask for your consent before we can start collecting this information, even if only kept locally.
+      Mozilla policy requires us to ask for your consent before we can collect this information, even if it is only stored locally.
     </p>
 
     <p>
-      Since this is the core functionality of this extension, if you do not consent, your only course of action is to uninstall.
+      This is the core functionality of this extension. If you do not agree, your only option is to uninstall it.
     </p>
   </div>
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Rewrites privacy notice in `static/consent.html` for clarity and corrects a typo.
> 
>   - **Textual Changes**:
>     - Corrects typo "wether" to "whether" in `static/consent.html`.
>     - Rephrases sentences for clarity in `static/consent.html`, such as changing "It is never sent elsewhere than to the local device" to "It is never sent anywhere other than to the local device".
>     - Simplifies language, e.g., "your only course of action is to uninstall" to "your only option is to uninstall it".
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ActivityWatch%2Faw-watcher-web&utm_source=github&utm_medium=referral)<sup> for 7a8f1f11dc7f157d2c7c42a3d6fc9f659a0cb4e5. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->