### PR TITLE
fix: fix event-driven background pages by awaiting heartbeat calls

### DIFF
--- a/src/background/heartbeat.ts
+++ b/src/background/heartbeat.ts
@@ -58,7 +58,7 @@ export const sendInitialHeartbeat = async (client: AWClient) => {
   const activeWindowTab = await getActiveWindowTab()
   const tabs = await getTabs()
   console.debug('Sending initial heartbeat', activeWindowTab)
-  heartbeat(client, activeWindowTab, tabs.length)
+  await heartbeat(client, activeWindowTab, tabs.length)
 }
 
 export const heartbeatAlarmListener =
@@ -68,7 +68,7 @@ export const heartbeatAlarmListener =
     if (!activeWindowTab) return
     const tabs = await getTabs()
     console.debug('Sending heartbeat for alarm', activeWindowTab)
-    heartbeat(client, activeWindowTab, tabs.length)
+    await heartbeat(client, activeWindowTab, tabs.length)
   }
 
 export const tabActivatedListener =
@@ -77,5 +77,5 @@ export const tabActivatedListener =
     const tab = await getTab(activeInfo.tabId)
     const tabs = await getTabs()
     console.debug('Sending heartbeat for tab activation', tab)
-    heartbeat(client, tab, tabs.length)
+    await heartbeat(client, tab, tabs.length)
   }

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -21,7 +21,7 @@
     "background": {
         "{{chrome}}.service_worker": "src/background/main.ts",
         "{{firefox}}.scripts": ["src/background/main.ts"],
-        "{{firefox}}.persistent": true
+        "{{firefox}}.persistent": false
     },
 
     "{{firefox}}.permissions": [


### PR DESCRIPTION
Attempted fixing https://github.com/ActivityWatch/aw-watcher-web/issues/112 by setting `persistent: true` in `manifest.json` (https://github.com/ActivityWatch/aw-watcher-web/commit/54980be352862e16ab119a5f589e3d04d8f584e3), but Mozilla prefers we don't do that, so this PR might fix the actual underlying issue without a persistent background page.

Might have unintentended negative consequences, needs to be vetted thoroughly.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add `await` to `heartbeat` calls in `heartbeat.ts` and set `persistent` to `false` in `manifest.json` for Firefox to fix event-driven background page issues.
> 
>   - **Behavior**:
>     - Add `await` to `heartbeat` calls in `sendInitialHeartbeat`, `heartbeatAlarmListener`, and `tabActivatedListener` in `heartbeat.ts` to ensure asynchronous operations complete.
>     - Set `persistent` to `false` in `manifest.json` for Firefox background scripts.
>   - **Potential Impact**:
>     - May fix issue with event-driven background pages without requiring persistent background pages.
>     - Needs thorough vetting for unintended negative consequences.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ActivityWatch%2Faw-watcher-web&utm_source=github&utm_medium=referral)<sup> for eee06dd8357fba22302eab71429a6c80eebc67a3. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->