### PR TITLE
feat: allow manually configuring the browser name

### DIFF
--- a/src/background/client.ts
+++ b/src/background/client.ts
@@ -2,7 +2,7 @@ import config from '../config'
 
 import { AWClient, IEvent } from 'aw-client'
 import retry from 'p-retry'
-import { emitNotification, getBrowserName, logHttpError } from './helpers'
+import { emitNotification, getBrowser, logHttpError } from './helpers'
 import { getSyncStatus, setSyncStatus } from '../storage'
 
 export const getClient = () =>
@@ -65,4 +65,7 @@ export async function sendHeartbeat(
     })
 }
 
-export const getBucketId = () => `aw-watcher-web-${getBrowserName()}`
+export const getBucketId = async (): Promise<string> => {
+  const browser = await getBrowser()
+  return `aw-watcher-web-${browser}`
+}

--- a/src/background/heartbeat.ts
+++ b/src/background/heartbeat.ts
@@ -37,7 +37,7 @@ async function heartbeat(
     console.debug('Sending heartbeat for previous data', previousData)
     await sendHeartbeat(
       client,
-      getBucketId(),
+      await getBucketId(),
       new Date(now.getTime() - 1),
       previousData,
       config.heartbeat.intervalInSeconds + 20,
@@ -46,7 +46,7 @@ async function heartbeat(
   console.debug('Sending heartbeat', data)
   await sendHeartbeat(
     client,
-    getBucketId(),
+    await getBucketId(),
     now,
     data,
     config.heartbeat.intervalInSeconds + 20,

--- a/src/background/helpers.ts
+++ b/src/background/helpers.ts
@@ -1,5 +1,6 @@
 import browser from 'webextension-polyfill'
 import { FetchError } from 'aw-client'
+import { getBrowserName, setBrowserName } from '../storage'
 
 export const getTab = (id: number) => browser.tabs.get(id)
 export const getTabs = (query: browser.Tabs.QueryQueryInfoType = {}) =>
@@ -23,8 +24,20 @@ export function emitNotification(title: string, message: string) {
   })
 }
 
+export const getBrowser = async (): Promise<string> => {
+  const storedName = await getBrowserName()
+  if (storedName) {
+    return storedName
+  }
+
+  const browserName = detectBrowser()
+
+  await setBrowserName(browserName)
+  return browserName
+}
+
 // FIXME: Detect Vivaldi? It seems to be intentionally impossible
-export const getBrowserName = () => {
+export const detectBrowser = () => {
   if ((navigator as any).brave?.isBrave()) {
     return 'brave'
   } else if (

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -24,6 +24,10 @@
         "{{firefox}}.persistent": true
     },
 
+    "options_ui": {
+        "page": "src/settings/index.html"
+    },
+
     "{{firefox}}.permissions": [
         "tabs",
         "alarms",

--- a/src/popup/index.html
+++ b/src/popup/index.html
@@ -56,6 +56,16 @@
           <!-- Filled by JS -->
         </td>
       </tr>
+
+      <tr>
+        <th align="right">Browser:</th>
+        <td>
+          <code id="status-browser">
+            <!-- Filled by JS -->
+          </code>
+          <button id="edit-btn">✎</button>
+        </td>
+      </tr>
     </table>
 
     <hr />

--- a/src/popup/main.ts
+++ b/src/popup/main.ts
@@ -8,6 +8,7 @@ import {
   setEnabled,
   watchSyncDate,
   watchSyncSuccess,
+  getBrowserName,
 } from '../storage'
 
 function setConnected(connected: boolean | undefined) {
@@ -31,6 +32,7 @@ async function renderStatus() {
   const enabled = await getEnabled()
   const syncStatus = await getSyncStatus()
   const consentStatus = await getConsentStatus()
+  const browserName = await getBrowserName()
 
   // Enabled checkbox
   const enabledCheckbox = document.getElementById('status-enabled-checkbox')
@@ -72,6 +74,11 @@ async function renderStatus() {
   if (!(webuiLink instanceof HTMLAnchorElement))
     throw Error('Web UI link is not an anchor')
   webuiLink.href = baseUrl ?? '#'
+
+  const browserNameElement = document.getElementById('status-browser')
+  if (!(browserNameElement instanceof HTMLElement))
+    throw Error('Browser name element is not defined')
+  browserNameElement.innerText = browserName
 }
 
 function domListeners() {
@@ -82,12 +89,20 @@ function domListeners() {
     const enabled = enabledCheckbox.checked
     setEnabled(enabled)
   })
+
   const consentButton = document.getElementById('status-consent-btn')!
   consentButton.addEventListener('click', () => {
     browser.tabs.create({
       active: true,
       url: browser.runtime.getURL('src/consent/index.html'),
     })
+  })
+
+  const browserButton = document.getElementById('edit-btn')
+  if (!(browserButton instanceof HTMLButtonElement))
+    throw Error('Edit button is not a button')
+  browserButton.addEventListener('click', () => {
+    browser.runtime.openOptionsPage()
   })
 }
 

--- a/src/settings/index.html
+++ b/src/settings/index.html
@@ -22,6 +22,7 @@
         <option value="vivaldi">Vivaldi</option>
         <option value="orion">Orion</option>
         <option value="yandex">Yandex</option>
+        <option value="zen">Zen</option>
         <option value="other">Other...</option>
       </select>
 

--- a/src/settings/index.html
+++ b/src/settings/index.html
@@ -31,7 +31,6 @@
         name="customBrowser"
         pattern="[a-z]*"
         placeholder="Custom browser name"
-        required
       />
 
       <button type="submit" class="accept">Save</button>

--- a/src/settings/index.html
+++ b/src/settings/index.html
@@ -8,33 +8,35 @@
 
   <body>
     <form>
-      <div style="display: flex; gap: 10px; align-items: center;">
-        <label for="browser">Browser:</label>
-        <select id="browser" name="browser">
-          <option value="chrome">Chrome</option>
-          <option value="firefox">Firefox</option>
-          <option value="opera">Opera</option>
-          <option value="brave">Brave</option>
-          <option value="edge">Edge</option>
-          <option value="arc">Arc</option>
-          <option value="vivaldi">Vivaldi</option>
-          <option value="orion">Orion</option>
-          <option value="yandex">Yandex</option>
-          <option value="other">Other...</option>
-        </select>
-        <div id="otherBrowserInput" style="display: none">
-          <input
-            type="text"
-            id="customBrowser"
-            name="customBrowser"
-            pattern="[a-z]*"
-            placeholder="Enter browser name"
-            required
-          />
-        </div>
-        <button type="submit" class="button accept">Save</button>
-      </div>
+      <label for="browser">
+        <strong>Browser:</strong>
+      </label>
+
+      <select id="browser" name="browser">
+        <option value="chrome">Chrome</option>
+        <option value="firefox">Firefox</option>
+        <option value="opera">Opera</option>
+        <option value="brave">Brave</option>
+        <option value="edge">Edge</option>
+        <option value="arc">Arc</option>
+        <option value="vivaldi">Vivaldi</option>
+        <option value="orion">Orion</option>
+        <option value="yandex">Yandex</option>
+        <option value="other">Other...</option>
+      </select>
+
+      <input
+        type="text"
+        id="customBrowser"
+        name="customBrowser"
+        pattern="[a-z]*"
+        placeholder="Custom browser name"
+        required
+      />
+
+      <button type="submit" class="accept">Save</button>
     </form>
+
     <script src="./main.js"></script>
   </body>
 </html>

--- a/src/settings/index.html
+++ b/src/settings/index.html
@@ -1,0 +1,40 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>ActivityWatch settings</title>
+    <link href="./style.css" rel="stylesheet" type="text/css" />
+  </head>
+
+  <body>
+    <form>
+      <div style="display: flex; gap: 10px; align-items: center;">
+        <label for="browser">Browser:</label>
+        <select id="browser" name="browser">
+          <option value="chrome">Chrome</option>
+          <option value="firefox">Firefox</option>
+          <option value="opera">Opera</option>
+          <option value="brave">Brave</option>
+          <option value="edge">Edge</option>
+          <option value="arc">Arc</option>
+          <option value="vivaldi">Vivaldi</option>
+          <option value="orion">Orion</option>
+          <option value="yandex">Yandex</option>
+          <option value="other">Other...</option>
+        </select>
+        <div id="otherBrowserInput" style="display: none">
+          <input
+            type="text"
+            id="customBrowser"
+            name="customBrowser"
+            pattern="[a-z]*"
+            placeholder="Enter browser name"
+            required
+          />
+        </div>
+        <button type="submit" class="button accept">Save</button>
+      </div>
+    </form>
+    <script src="./main.js"></script>
+  </body>
+</html>

--- a/src/settings/main.ts
+++ b/src/settings/main.ts
@@ -1,0 +1,87 @@
+import browser from 'webextension-polyfill'
+import { getBrowserName, setBrowserName } from '../storage'
+
+interface HTMLElementEvent<T extends HTMLElement> extends Event {
+    target: T
+}
+
+async function reloadExtension(): Promise<void> {
+    browser.runtime.reload()
+}
+
+async function saveOptions(e: SubmitEvent): Promise<void> {
+    e.preventDefault()
+
+    const browserSelect = document.querySelector<HTMLSelectElement>('#browser')
+    const customBrowserInput =
+        document.querySelector<HTMLInputElement>('#customBrowser')
+    if (!browserSelect) return
+
+    let selectedBrowser = browserSelect.value
+    if (selectedBrowser === 'other' && customBrowserInput?.value) {
+        selectedBrowser = customBrowserInput.value.toLowerCase()
+    }
+
+    const form = e.target as HTMLFormElement
+    const button = form.querySelector<HTMLButtonElement>('button')
+    if (!button) return
+
+    button.textContent = 'Saving...'
+    button.classList.remove('accept')
+
+    try {
+        await setBrowserName(selectedBrowser)
+        await reloadExtension()
+        button.textContent = 'Save'
+        button.classList.add('accept')
+    } catch (error) {
+        console.error('Failed to save options:', error)
+        button.textContent = 'Error'
+        button.classList.add('error')
+    }
+}
+
+function toggleCustomBrowserInput(): void {
+    const browserSelect = document.querySelector<HTMLSelectElement>('#browser')
+    const customInput = document.querySelector<HTMLInputElement>('#customBrowser')
+    const otherBrowserInput =
+        document.querySelector<HTMLDivElement>('#otherBrowserInput')
+
+    if (browserSelect && customInput && otherBrowserInput) {
+        const isOther = browserSelect.value === 'other'
+        otherBrowserInput.style.display = isOther ? 'block' : 'none'
+        customInput.required = isOther
+    }
+}
+
+async function restoreOptions(): Promise<void> {
+    try {
+        const browserName = await getBrowserName()
+        const browserSelect = document.querySelector<HTMLSelectElement>('#browser')
+        const otherBrowserInput = document.querySelector<HTMLDivElement>('#otherBrowserInput')
+        const customInput = document.querySelector<HTMLInputElement>('#customBrowser')
+
+        if (!browserSelect || !otherBrowserInput || !customInput || !browserName) return
+
+        const standardBrowsers = Array.from(browserSelect.options).map(opt => opt.value)
+        if (!standardBrowsers.includes(browserName)) {
+            browserSelect.value = 'other'
+            otherBrowserInput.style.display = 'block'
+            customInput.value = browserName
+            customInput.required = true
+        } else {
+            browserSelect.value = browserName
+        }
+    } catch (error) {
+        console.error('Failed to restore options:', error)
+    }
+}
+
+document.addEventListener('DOMContentLoaded', restoreOptions)
+document
+    .querySelector('#browser')
+    ?.addEventListener('change', toggleCustomBrowserInput)
+const form = document.querySelector('form')
+if (form) {
+    form.addEventListener('submit', saveOptions as EventListener)
+}

--- a/src/settings/main.ts
+++ b/src/settings/main.ts
@@ -2,86 +2,92 @@ import browser from 'webextension-polyfill'
 import { getBrowserName, setBrowserName } from '../storage'
 
 interface HTMLElementEvent<T extends HTMLElement> extends Event {
-    target: T
+  target: T
 }
 
 async function reloadExtension(): Promise<void> {
-    browser.runtime.reload()
+  browser.runtime.reload()
 }
 
 async function saveOptions(e: SubmitEvent): Promise<void> {
-    e.preventDefault()
+  e.preventDefault()
 
-    const browserSelect = document.querySelector<HTMLSelectElement>('#browser')
-    const customBrowserInput =
-        document.querySelector<HTMLInputElement>('#customBrowser')
-    if (!browserSelect) return
+  const browserSelect = document.querySelector<HTMLSelectElement>('#browser')
+  const customBrowserInput =
+    document.querySelector<HTMLInputElement>('#customBrowser')
+  if (!browserSelect) return
 
-    let selectedBrowser = browserSelect.value
-    if (selectedBrowser === 'other' && customBrowserInput?.value) {
-        selectedBrowser = customBrowserInput.value.toLowerCase()
-    }
+  let selectedBrowser = browserSelect.value
+  if (selectedBrowser === 'other' && customBrowserInput?.value) {
+    selectedBrowser = customBrowserInput.value.toLowerCase()
+  }
 
-    const form = e.target as HTMLFormElement
-    const button = form.querySelector<HTMLButtonElement>('button')
-    if (!button) return
+  const form = e.target as HTMLFormElement
+  const button = form.querySelector<HTMLButtonElement>('button')
+  if (!button) return
 
-    button.textContent = 'Saving...'
-    button.classList.remove('accept')
+  button.textContent = 'Saving...'
+  button.classList.remove('accept')
 
-    try {
-        await setBrowserName(selectedBrowser)
-        await reloadExtension()
-        button.textContent = 'Save'
-        button.classList.add('accept')
-    } catch (error) {
-        console.error('Failed to save options:', error)
-        button.textContent = 'Error'
-        button.classList.add('error')
-    }
+  try {
+    await setBrowserName(selectedBrowser)
+    await reloadExtension()
+    button.textContent = 'Save'
+    button.classList.add('accept')
+  } catch (error) {
+    console.error('Failed to save options:', error)
+    button.textContent = 'Error'
+    button.classList.add('error')
+  }
 }
 
 function toggleCustomBrowserInput(): void {
-    const browserSelect = document.querySelector<HTMLSelectElement>('#browser')
-    const customInput = document.querySelector<HTMLInputElement>('#customBrowser')
-    const otherBrowserInput =
-        document.querySelector<HTMLDivElement>('#otherBrowserInput')
+  const browserSelect = document.querySelector<HTMLSelectElement>('#browser')
+  const customInput = document.querySelector<HTMLInputElement>('#customBrowser')
 
-    if (browserSelect && customInput && otherBrowserInput) {
-        const isOther = browserSelect.value === 'other'
-        otherBrowserInput.style.display = isOther ? 'block' : 'none'
-        customInput.required = isOther
-    }
+  if (browserSelect && customInput) {
+    const isOther = browserSelect.value === 'other'
+    customInput.style.display = isOther ? 'block' : 'none'
+    customInput.required = isOther
+  }
 }
 
 async function restoreOptions(): Promise<void> {
-    try {
-        const browserName = await getBrowserName()
-        const browserSelect = document.querySelector<HTMLSelectElement>('#browser')
-        const otherBrowserInput = document.querySelector<HTMLDivElement>('#otherBrowserInput')
-        const customInput = document.querySelector<HTMLInputElement>('#customBrowser')
+  try {
+    const browserName = await getBrowserName()
+    const browserSelect = document.querySelector<HTMLSelectElement>('#browser')
+    const customInput =
+      document.querySelector<HTMLInputElement>('#customBrowser')
 
-        if (!browserSelect || !otherBrowserInput || !customInput || !browserName) return
+    if (!browserSelect || !customInput || !browserName) return
 
-        const standardBrowsers = Array.from(browserSelect.options).map(opt => opt.value)
-        if (!standardBrowsers.includes(browserName)) {
-            browserSelect.value = 'other'
-            otherBrowserInput.style.display = 'block'
-            customInput.value = browserName
-            customInput.required = true
-        } else {
-            browserSelect.value = browserName
-        }
-    } catch (error) {
-        console.error('Failed to restore options:', error)
+    const standardBrowsers = Array.from(browserSelect.options).map(
+      (opt) => opt.value,
+    )
+    if (!standardBrowsers.includes(browserName)) {
+      browserSelect.value = 'other'
+      customInput.style.display = 'block'
+      customInput.value = browserName
+      customInput.required = true
+    } else {
+      browserSelect.value = browserName
+      customInput.style.display = 'none'
+      customInput.required = false
     }
+  } catch (error) {
+    console.error('Failed to restore options:', error)
+  }
 }
 
-document.addEventListener('DOMContentLoaded', restoreOptions)
+document.addEventListener('DOMContentLoaded', () => {
+  restoreOptions()
+  toggleCustomBrowserInput()
+})
+
 document
-    .querySelector('#browser')
-    ?.addEventListener('change', toggleCustomBrowserInput)
+  .querySelector('#browser')
+  ?.addEventListener('change', toggleCustomBrowserInput)
 const form = document.querySelector('form')
 if (form) {
-    form.addEventListener('submit', saveOptions as EventListener)
+  form.addEventListener('submit', saveOptions as EventListener)
 }

--- a/src/settings/style.css
+++ b/src/settings/style.css
@@ -1,41 +1,14 @@
 body {
   font-family: 'Segoe UI', 'Lucida Grande', Tahoma, sans-serif;
-  font-size: 100%;
-  width: 25em;
 }
 
-hr {
-  border: 1px solid #ddd;
-}
-
-a {
-  text-decoration: none;
-}
-
-button {
-  cursor: pointer;
-}
-
-.button {
-  display: inline-block;
-  color: #333333;
-  padding: 0.5em;
-  margin: 0.5em 0 0.5em 0.5em;
-  border-radius: 0.2em;
-  background-color: #eee;
-  border: 1px solid #ddd;
-}
-
-#status-consent-btn {
-  display: none;
-}
-
-#otherBrowserInput {
-  margin-top: 10px;
+form {
+  display: flex;
+  gap: 10px;
+  align-items: center;
+  margin: 0.5em;
 }
 
 #customBrowser {
-  width: 100%;
-  padding: 5px;
-  box-sizing: border-box;
+  display: none;
 }

--- a/src/settings/style.css
+++ b/src/settings/style.css
@@ -30,10 +30,12 @@ button {
   display: none;
 }
 
-form {
-  margin: 0 0.5em;
+#otherBrowserInput {
+  margin-top: 10px;
 }
 
-label {
-  font-weight: bold;
+#customBrowser {
+  width: 100%;
+  padding: 5px;
+  box-sizing: border-box;
 }

--- a/src/storage.ts
+++ b/src/storage.ts
@@ -84,3 +84,9 @@ export const getHeartbeatData = (): Promise<HeartbeatData | undefined> =>
     .then((_) => _.heartbeatData as HeartbeatData | undefined)
 export const setHeartbeatData = (heartbeatData: HeartbeatData) =>
   browser.storage.local.set({ heartbeatData })
+
+type BrowserName = string
+export const getBrowserName = (): Promise<BrowserName | undefined> =>
+  browser.storage.local.get('browserName').then((_) => _.browserName)
+export const setBrowserName = (browserName: BrowserName) =>
+  browser.storage.local.set({ browserName })

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -20,12 +20,7 @@ export default defineConfig({
   plugins: [
     webExtension({
       manifest: generateManifest,
-      additionalInputs: [
-        'src/consent/index.html',
-        'src/consent/main.ts',
-        'src/settings/index.html',
-        'src/settings/main.ts',
-      ],
+      additionalInputs: ['src/consent/index.html', 'src/consent/main.ts'],
       browser: process.env.VITE_TARGET_BROWSER,
     }),
   ],

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -20,7 +20,12 @@ export default defineConfig({
   plugins: [
     webExtension({
       manifest: generateManifest,
-      additionalInputs: ['src/consent/index.html', 'src/consent/main.ts'],
+      additionalInputs: [
+        'src/consent/index.html',
+        'src/consent/main.ts',
+        'src/settings/index.html',
+        'src/settings/main.ts',
+      ],
       browser: process.env.VITE_TARGET_BROWSER,
     }),
   ],


### PR DESCRIPTION
<img width="52%" src="https://github.com/user-attachments/assets/0ee969fc-64c0-4e7b-a407-ad9265d66056" />
<img width="47%" src="https://github.com/user-attachments/assets/9feec390-5aa7-422e-8549-244fc64a456e" />
<p align=center>
  <img width="70%" src="https://github.com/user-attachments/assets/398c8914-55d9-4f23-a38c-58e2d82c998e" />
</p>

---

- Fixes https://github.com/ActivityWatch/aw-watcher-web/issues/77
- Fixes https://github.com/ActivityWatch/aw-watcher-web/issues/88
- Fixes https://github.com/ActivityWatch/aw-watcher-web/issues/90
- Fixes https://github.com/ActivityWatch/aw-watcher-web/issues/91
- Fixes https://github.com/ActivityWatch/aw-watcher-web/issues/92
- Fixes https://github.com/ActivityWatch/aw-watcher-web/issues/118
- Fixes https://github.com/ActivityWatch/activitywatch/issues/774
- Fixes https://github.com/ActivityWatch/activitywatch/issues/942
- Fixes https://github.com/ActivityWatch/activitywatch/issues/1094
- Closes https://github.com/ActivityWatch/aw-webui/pull/622
- Closes https://github.com/ActivityWatch/aw-watcher-web/pull/149
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Adds manual browser name configuration to ActivityWatch extension with UI and storage support.
> 
>   - **Behavior**:
>     - Allows manual configuration of browser name via a new settings page (`src/settings/index.html`).
>     - Updates `getBucketId()` in `client.ts` to use `getBrowser()` which retrieves the browser name from storage.
>     - Adds a button in `popup/index.html` to open the settings page for browser name configuration.
>   - **Functions**:
>     - Adds `getBrowser()` in `helpers.ts` to fetch the browser name from storage or detect it if not set.
>     - Adds `setBrowserName()` and `getBrowserName()` in `storage.ts` to manage browser name in local storage.
>   - **UI**:
>     - Adds a dropdown and input field in `settings/index.html` for selecting or entering a custom browser name.
>     - Updates `popup/main.ts` to display the current browser name and provide a button to edit it.
>   - **Misc**:
>     - Renames `getBrowserName()` to `detectBrowser()` in `helpers.ts` to clarify its purpose.
>     - Updates `manifest.json` to include the new settings page.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ActivityWatch%2Faw-watcher-web&utm_source=github&utm_medium=referral)<sup> for 9f6d2e944586a0f05be7648c5cd635bdad58db9a. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->