### PR TITLE
fix: fixed incorrectly referenced ts module in new settings popup

### DIFF
--- a/src/settings/index.html
+++ b/src/settings/index.html
@@ -37,6 +37,6 @@
       <button type="submit" class="accept">Save</button>
     </form>
 
-    <script src="./main.js"></script>
+    <script type="module" src="./main.ts"></script>
   </body>
 </html>


### PR DESCRIPTION
I noticed the popup wasn't working after I cloned, built and installed the extension afresh after https://github.com/ActivityWatch/aw-watcher-web/pull/154 - settings/main.ts wasn't being built when using `make build-chrome`.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes script loading issue in `index.html` by changing source from `main.js` to `main.ts`.
> 
>   - **Behavior**:
>     - Fixes issue where `settings/main.ts` was not being built when using `make build-chrome`.
>     - Changes script source in `index.html` from `main.js` to `main.ts` to ensure correct module loading.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ActivityWatch%2Faw-watcher-web&utm_source=github&utm_medium=referral)<sup> for 555e0a9668abb550f0787cbcecf6e2c6e295c9aa. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->