### PR TITLE
fix: enable persistent background script for Firefox

### DIFF
--- a/src/manifest.json
+++ b/src/manifest.json
@@ -21,7 +21,7 @@
     "background": {
         "{{chrome}}.service_worker": "src/background/main.ts",
         "{{firefox}}.scripts": ["src/background/main.ts"],
-        "{{firefox}}.persistent": false
+        "{{firefox}}.persistent": true
     },
 
     "options_ui": {


### PR DESCRIPTION
- Fixes https://github.com/ActivityWatch/aw-watcher-web/issues/166
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Enable persistent background scripts for Firefox by setting `{{firefox}}.persistent` to `true` in `manifest.json`.
> 
>   - **Behavior**:
>     - Sets `{{firefox}}.persistent` to `true` in `manifest.json` to enable persistent background scripts for Firefox.
>     - Fixes issue #166 in the `aw-watcher-web` repository.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ActivityWatch%2Faw-watcher-web&utm_source=github&utm_medium=referral)<sup> for 8037072b1d532e12c7d501a60b157a4b48462db9. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->