### PR TITLE
fix: close settings popup for non-Firefox browsers

### DIFF
--- a/src/settings/main.ts
+++ b/src/settings/main.ts
@@ -5,9 +5,15 @@ import {
   getHostname,
   setHostname,
 } from '../storage'
+import { detectBrowser } from '../background/helpers'
 
 async function reloadExtension(): Promise<void> {
   browser.runtime.reload()
+
+  // Close the settings popup on Chromium based browsers
+  if (detectBrowser() !== 'firefox') {
+    window.close()
+  }
 }
 
 async function saveOptions(e: SubmitEvent): Promise<void> {


### PR DESCRIPTION
On Chromium-based browsers, the pop-up doesn't automatically close when the extension reloads, allowing users to click the save button multiple times and cause errors
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Close settings popup for non-Firefox browsers in `reloadExtension()` in `main.ts`.
> 
>   - **Behavior**:
>     - In `main.ts`, `reloadExtension()` now closes the settings popup for non-Firefox browsers using `window.close()`.
>     - Specifically targets Chromium-based browsers by checking `detectBrowser() !== 'firefox'`.
>   - **Misc**:
>     - No changes to existing functionality for Firefox users.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ActivityWatch%2Faw-watcher-web&utm_source=github&utm_medium=referral)<sup> for dbc7296bd30ebd060b3d7d7b27d994c842d37b19. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->