### PR TITLE
fix: don't rely on manual file size parsing in CI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -70,13 +70,10 @@ test-reproducibility-chrome: zip-src build-chrome test-reproducibility-setup
 	@(cd build/aw-watcher-web && make build-chrome && cp artifacts/chrome.zip ../../artifacts/reproducibility-chrome.zip)
 	@rm -r build/aw-watcher-web
 	@echo "Checking..."
-	@wc -c artifacts/chrome.zip artifacts/reproducibility-chrome.zip | \
-		sort -n | \
-		cut -d' ' -f2 | \
-		uniq -c | \
-		grep -q ' 2 ' \
-	|| (echo "build artifacts not the same size" && exit 1)
-	@echo "✅ Reproducibility test passed"
+	@test "$$(wc -c artifacts/chrome.zip | awk '{print $$1}')" = \
+		"$$(wc -c artifacts/reproducibility-chrome.zip | awk '{print $$1}')" \
+		|| (echo "❌ Build artifacts are not the same size" && exit 1)
+	@echo "✅ Build artifacts are the same size"
 
 # Tests whether the zipped src reliably builds the same as the archive
 test-reproducibility-firefox: zip-src build-firefox test-reproducibility-setup
@@ -84,10 +81,7 @@ test-reproducibility-firefox: zip-src build-firefox test-reproducibility-setup
 	@(cd build/aw-watcher-web && make build-firefox && cp artifacts/firefox.zip ../../artifacts/reproducibility-firefox.zip)
 	@rm -r build/aw-watcher-web
 	@echo "Checking..."
-	@wc -c artifacts/firefox.zip artifacts/reproducibility-firefox.zip | \
-		sort -n | \
-		cut -d' ' -f2 | \
-		uniq -c | \
-		grep -q ' 2 ' \
-	|| (echo "build artifacts not the same size" && exit 1)
-	@echo "✅ Reproducibility test passed"
+	@test "$$(wc -c artifacts/firefox.zip | awk '{print $$1}')" = \
+		"$$(wc -c artifacts/reproducibility-firefox.zip | awk '{print $$1}')" \
+		|| (echo "❌ Build artifacts are not the same size" && exit 1)
+	@echo "✅ Build artifacts are the same size"


### PR DESCRIPTION
The size of the built file has changed the number of digits, and manual parsing by splitting on spaces doesn't work anymore
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Replaces manual file size parsing with `awk` in `Makefile` to ensure accurate file size comparison in CI reproducibility tests.
> 
>   - **Behavior**:
>     - Replaces manual file size parsing with `awk` in `test-reproducibility-chrome` and `test-reproducibility-firefox` in `Makefile`.
>     - Ensures accurate file size comparison regardless of digit count.
>   - **Misc**:
>     - Removes sorting and unique counting logic from reproducibility tests.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ActivityWatch%2Faw-watcher-web&utm_source=github&utm_medium=referral)<sup> for bf53ce0d9aefe82f278e45a916a7ef7828e17055. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->