### PR TITLE
fix: prevent termination of Chrome service worker

### DIFF
--- a/src/background/main.ts
+++ b/src/background/main.ts
@@ -75,3 +75,30 @@ setBaseUrl(client.baseURL)
   .then(waitForEnabled)
   .then(() => sendInitialHeartbeat(client))
   .then(() => console.info('Started successfully'))
+
+/**
+ * Keep the service worker alive to prevent Chrome's 5-minute inactivity termination
+ * This is a workaround for Chrome's behavior of terminating inactive service workers
+ */
+if (import.meta.env.VITE_TARGET_BROWSER === 'chrome') {
+  function setupKeepAlive(): void {
+    console.debug(
+      'Setting up keep-alive ping to prevent service worker termination',
+    )
+
+    setInterval(
+      () => {
+        console.debug('Keep-alive ping')
+        // Force some minimal activity
+        browser.alarms
+          .get(config.heartbeat.alarmName)
+          .then(() => console.debug('Keep-alive ping completed'))
+          .catch((err) => console.error('Keep-alive ping failed:', err))
+      },
+      4 * 60 * 1000,
+    ) // 4 minutes (less than Chrome's ~5 minute timeout)
+  }
+
+  // Start the keep-alive mechanism
+  setupKeepAlive()
+}

--- a/src/background/main.ts
+++ b/src/background/main.ts
@@ -79,6 +79,7 @@ setBaseUrl(client.baseURL)
 /**
  * Keep the service worker alive to prevent Chrome's 5-minute inactivity termination
  * This is a workaround for Chrome's behavior of terminating inactive service workers
+ * https://stackoverflow.com/questions/66618136
  */
 if (import.meta.env.VITE_TARGET_BROWSER === 'chrome') {
   function setupKeepAlive(): void {


### PR DESCRIPTION
Manually tested, finally works as intended :)
Inspired by: https://stackoverflow.com/questions/66618136

---

- Fixes https://github.com/ActivityWatch/aw-watcher-web/issues/173

---

![](https://github.com/user-attachments/assets/3a8d5262-928b-45af-8b0a-aa246e79a806)

---
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Implements a keep-alive mechanism in `main.ts` to prevent Chrome from terminating inactive service workers, addressing issue #173.
> 
>   - **Behavior**:
>     - Implements a keep-alive mechanism in `main.ts` to prevent Chrome from terminating inactive service workers.
>     - Uses `setInterval` to send a keep-alive ping every 4 minutes, less than Chrome's 5-minute timeout.
>     - Logs debug messages for keep-alive pings and errors.
>   - **Environment**:
>     - The keep-alive mechanism is only activated if `VITE_TARGET_BROWSER` is set to 'chrome'.
>   - **Issue Fix**:
>     - Fixes issue #173 in `aw-watcher-web`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ActivityWatch%2Faw-watcher-web&utm_source=github&utm_medium=referral)<sup> for 19321a96c8e42f0fd5b7fb336a6dee568961fbbc. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->