### PR TITLE
fix: update Chrome host permissions to allow all URLs

### DIFF
--- a/src/manifest.json
+++ b/src/manifest.json
@@ -45,8 +45,7 @@
         "storage"
     ],
     "{{chrome}}.host_permissions": [
-        "http://127.0.0.1:5600/api/*",
-        "http://127.0.0.1:5666/api/*"
+        "<all_urls>"
     ],
 
     "{{firefox}}.browser_specific_settings": {

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -44,9 +44,7 @@
         "activeTab",
         "storage"
     ],
-    "{{chrome}}.host_permissions": [
-        "<all_urls>"
-    ],
+    "{{chrome}}.host_permissions": ["<all_urls>"],
 
     "{{firefox}}.browser_specific_settings": {
         "gecko": {


### PR DESCRIPTION
- Fixes https://github.com/ActivityWatch/aw-watcher-web/issues/182
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Updates Chrome host permissions in `manifest.json` to allow all URLs, fixing issue #182.
> 
>   - **Permissions**:
>     - Updates `{{chrome}}.host_permissions` in `manifest.json` to `"<all_urls>"`, allowing the extension to access all URLs.
>   - **Issue Fix**:
>     - Fixes issue #182 in the `aw-watcher-web` repository.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ActivityWatch%2Faw-watcher-web&utm_source=github&utm_medium=referral)<sup> for ce0027926a4354040e50b4da0407205a3041b857. You can [customize](https://app.ellipsis.dev/ActivityWatch/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->