### PR TITLE
Add profile name functionality to heartbeat and settings

### DIFF
--- a/src/background/heartbeat.ts
+++ b/src/background/heartbeat.ts
@@ -3,7 +3,7 @@ import { getActiveWindowTab, getTab, getTabs } from './helpers'
 import config from '../config'
 import { AWClient, IEvent } from 'aw-client'
 import { getBucketId, sendHeartbeat } from './client'
-import { getEnabled, getHeartbeatData, setHeartbeatData } from '../storage'
+import { getEnabled, getHeartbeatData, setHeartbeatData, getDisplayProfileName } from '../storage'
 import deepEqual from 'deep-equal'
 
 async function heartbeat(
@@ -28,12 +28,15 @@ async function heartbeat(
   }
 
   const now = new Date()
+  const profileName = await getDisplayProfileName()
+  
   const data: IEvent['data'] = {
     url: tab.url,
     title: tab.title,
     audible: tab.audible ?? false,
     incognito: tab.incognito,
     tabCount: tabCount,
+    profileName: profileName,
   }
   const previousData = await getHeartbeatData()
   if (previousData && !deepEqual(previousData, data)) {

--- a/src/background/main.ts
+++ b/src/background/main.ts
@@ -14,6 +14,7 @@ import {
   setEnabled,
   setHostname,
   waitForEnabled,
+  generateProfileIdentifier,
 } from '../storage'
 
 async function getIsConsentRequired() {
@@ -32,6 +33,11 @@ async function autodetectHostname() {
       setHostname(detectedHostname)
     }
   }
+}
+
+async function initializeProfileIdentifier() {
+  await generateProfileIdentifier()
+  console.debug('Profile identifier initialized')
 }
 
 /** Init */
@@ -58,6 +64,7 @@ browser.runtime.onInstalled.addListener(async () => {
   }
 
   await autodetectHostname()
+  await initializeProfileIdentifier()
 })
 
 console.debug('Creating alarms and tab listeners')

--- a/src/popup/index.html
+++ b/src/popup/index.html
@@ -79,6 +79,15 @@
           </code>
         </td>
       </tr>
+
+      <tr>
+        <th align="right">Profile:</th>
+        <td>
+          <code id="status-profile">
+            <!-- Filled by JS -->
+          </code>
+        </td>
+      </tr>
     </table>
 
     <hr />

--- a/src/popup/main.ts
+++ b/src/popup/main.ts
@@ -10,6 +10,7 @@ import {
   watchSyncSuccess,
   getBrowserName,
   getHostname,
+  getDisplayProfileName,
 } from '../storage'
 
 function setConnected(connected: boolean | undefined) {
@@ -35,6 +36,7 @@ async function renderStatus() {
   const consentStatus = await getConsentStatus()
   const browserName = await getBrowserName()
   const hostname = await getHostname()
+  const profileName = await getDisplayProfileName()
 
   // Enabled checkbox
   const enabledCheckbox = document.getElementById('status-enabled-checkbox')
@@ -88,6 +90,12 @@ async function renderStatus() {
   if (!(hostnameElement instanceof HTMLElement))
     throw Error('Hostname element is not defined')
   hostnameElement.innerText = hostname ?? 'unknown'
+
+  // Profile
+  const profileElement = document.getElementById('status-profile')
+  if (!(profileElement instanceof HTMLElement))
+    throw Error('Profile element is not defined')
+  profileElement.innerText = profileName
 }
 
 function domListeners() {

--- a/src/settings/index.html
+++ b/src/settings/index.html
@@ -51,6 +51,20 @@
       </div>
 
       <div>
+        <label for="profileName">
+          <strong>Profile Name:</strong>
+        </label>
+
+        <input
+          type="text"
+          id="profileName"
+          name="profileName"
+          pattern="[a-zA-Z0-9_.\- ]*"
+          placeholder="Custom profile name (optional)"
+        />
+      </div>
+
+      <div>
         <button type="submit">Save</button>
       </div>
     </form>

--- a/src/settings/main.ts
+++ b/src/settings/main.ts
@@ -4,6 +4,8 @@ import {
   setBrowserName,
   getHostname,
   setHostname,
+  getCustomProfileName,
+  setCustomProfileName,
 } from '../storage'
 import { detectBrowser } from '../background/helpers'
 
@@ -34,6 +36,9 @@ async function saveOptions(e: SubmitEvent): Promise<void> {
 
   const hostname = hostnameInput.value
 
+  const profileNameInput = document.querySelector<HTMLInputElement>('#profileName')
+  const profileName = profileNameInput?.value.trim() || ''
+
   const form = e.target as HTMLFormElement
   const button = form.querySelector<HTMLButtonElement>('button')
   if (!button) return
@@ -44,6 +49,10 @@ async function saveOptions(e: SubmitEvent): Promise<void> {
   try {
     await setBrowserName(selectedBrowser)
     await setHostname(hostname)
+    
+    // Save custom profile name (empty string clears it)
+    await setCustomProfileName(profileName)
+    
     await reloadExtension()
     button.textContent = 'Save'
     button.classList.add('accept')
@@ -94,6 +103,13 @@ async function restoreOptions(): Promise<void> {
 
     if (hostname !== undefined) {
       hostnameInput.value = hostname
+    }
+
+    // Restore custom profile name
+    const customProfileName = await getCustomProfileName()
+    const profileNameInput = document.querySelector<HTMLInputElement>('#profileName')
+    if (profileNameInput && customProfileName) {
+      profileNameInput.value = customProfileName
     }
   } catch (error) {
     console.error('Failed to restore options:', error)

--- a/src/storage.ts
+++ b/src/storage.ts
@@ -101,3 +101,49 @@ export const getHostname = (): Promise<Hostname | undefined> =>
     .then((data: StorageData) => data.hostname as string | undefined)
 export const setHostname = (hostname: Hostname) =>
   browser.storage.local.set({ hostname })
+
+type ProfileIdentifier = string
+export const getProfileIdentifier = (): Promise<ProfileIdentifier | undefined> =>
+  browser.storage.local
+    .get('profileIdentifier')
+    .then((data: StorageData) => data.profileIdentifier as string | undefined)
+
+export const setProfileIdentifier = (profileIdentifier: ProfileIdentifier) =>
+  browser.storage.local.set({ profileIdentifier })
+
+export const generateProfileIdentifier = async (): Promise<ProfileIdentifier> => {
+  const existing = await getProfileIdentifier()
+  if (existing) {
+    return existing
+  }
+  
+  // Generate a unique identifier for this profile/installation
+  const profileId = crypto.randomUUID()
+  await setProfileIdentifier(profileId)
+  return profileId
+}
+
+type CustomProfileName = string
+export const getCustomProfileName = (): Promise<CustomProfileName | undefined> =>
+  browser.storage.local
+    .get('customProfileName')
+    .then((data: StorageData) => data.customProfileName as string | undefined)
+
+export const setCustomProfileName = (customProfileName: CustomProfileName) => {
+  if (customProfileName.trim() === '') {
+    // Remove custom profile name if empty string is provided
+    return browser.storage.local.remove('customProfileName')
+  }
+  return browser.storage.local.set({ customProfileName })
+}
+
+export const getDisplayProfileName = async (): Promise<string> => {
+  const customName = await getCustomProfileName()
+  if (customName) {
+    return customName
+  }
+  
+  // Fallback to a shortened version of the unique identifier
+  const profileId = await generateProfileIdentifier()
+  return `Profile-${profileId.slice(0, 8)}`
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,5 +1,7 @@
 import { defineConfig } from 'vite'
 import webExtension, { readJsonFile } from 'vite-plugin-web-extension'
+import { copyFileSync, existsSync } from 'fs'
+import { resolve } from 'path'
 
 function generateManifest() {
   const manifest = readJsonFile('src/manifest.json')
@@ -23,5 +25,19 @@ export default defineConfig({
       additionalInputs: ['src/consent/index.html', 'src/consent/main.ts'],
       browser: process.env.VITE_TARGET_BROWSER,
     }),
+    // Custom plugin to copy logo file
+    {
+      name: 'copy-logo',
+      buildStart() {
+        const logoSrc = resolve('media/logo/logo-128.png')
+        const logoDest = resolve('build/logo-128.png')
+        if (existsSync(logoSrc)) {
+          copyFileSync(logoSrc, logoDest)
+          console.log('Copied logo-128.png to build directory')
+        } else {
+          console.warn('Logo file not found at media/logo/logo-128.png')
+        }
+      },
+    },
   ],
 })

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,7 +1,5 @@
 import { defineConfig } from 'vite'
 import webExtension, { readJsonFile } from 'vite-plugin-web-extension'
-import { copyFileSync, existsSync } from 'fs'
-import { resolve } from 'path'
 
 function generateManifest() {
   const manifest = readJsonFile('src/manifest.json')
@@ -24,20 +22,6 @@ export default defineConfig({
       manifest: generateManifest,
       additionalInputs: ['src/consent/index.html', 'src/consent/main.ts'],
       browser: process.env.VITE_TARGET_BROWSER,
-    }),
-    // Custom plugin to copy logo file
-    {
-      name: 'copy-logo',
-      buildStart() {
-        const logoSrc = resolve('media/logo/logo-128.png')
-        const logoDest = resolve('build/logo-128.png')
-        if (existsSync(logoSrc)) {
-          copyFileSync(logoSrc, logoDest)
-          console.log('Copied logo-128.png to build directory')
-        } else {
-          console.warn('Logo file not found at media/logo/logo-128.png')
-        }
-      },
-    },
+    }),    
   ],
 })


### PR DESCRIPTION
Allow users to set a custom profile name, which can improve the identification of user sessions and preferences. E.g.
Work profile for client X, Personal, etc.

* Introduced `getDisplayProfileName` to retrieve the profile name in the heartbeat function.
* Added a new input field for custom profile name in the settings interface.
* Implemented `generateProfileIdentifier`
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds custom profile name functionality to heartbeat and settings, including UI input and storage handling.
> 
>   - **Behavior**:
>     - Adds `profileName` to heartbeat data in `heartbeat.ts` using `getDisplayProfileName()`.
>     - Initializes profile identifier in `main.ts` with `generateProfileIdentifier()`.
>   - **Settings UI**:
>     - Adds input field for `profileName` in `index.html`.
>     - Handles saving and restoring `profileName` in `main.ts`.
>   - **Storage**:
>     - Implements `getCustomProfileName`, `setCustomProfileName`, and `getDisplayProfileName` in `storage.ts`.
>     - Adds `generateProfileIdentifier` to create unique profile identifiers.
>   - **Misc**:
>     - Adds a custom Vite plugin in `vite.config.ts` to copy logo files during build.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ActivityWatch%2Faw-watcher-web&utm_source=github&utm_medium=referral)<sup> for 116d29b446bc854469ca00a3084385314552507c. You can [customize](https://app.ellipsis.dev/ActivityWatch/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->