### PR TITLE
chrome. implement offscreen document to keep service worker alive

### DIFF
--- a/src/background/main.ts
+++ b/src/background/main.ts
@@ -77,29 +77,34 @@ setBaseUrl(client.baseURL)
   .then(() => console.info('Started successfully'))
 
 /**
- * Keep the service worker alive to prevent Chrome's 5-minute inactivity termination
- * This is a workaround for Chrome's behavior of terminating inactive service workers
- * https://stackoverflow.com/questions/66618136
+ * Keep the service worker alive using Offscreen API to prevent Chrome's termination.
  */
-if (import.meta.env.VITE_TARGET_BROWSER === 'chrome') {
-  function setupKeepAlive(): void {
-    console.debug(
-      'Setting up keep-alive ping to prevent service worker termination',
-    )
+async function setupOffscreen() {
+  const _chrome = (globalThis as any).chrome
+  if (typeof _chrome === 'undefined' || !_chrome.offscreen) return
 
-    setInterval(
-      () => {
-        console.debug('Keep-alive ping')
-        // Force some minimal activity
-        browser.alarms
-          .get(config.heartbeat.alarmName)
-          .then(() => console.debug('Keep-alive ping completed'))
-          .catch((err) => console.error('Keep-alive ping failed:', err))
-      },
-      4 * 60 * 1000,
-    ) // 4 minutes (less than Chrome's ~5 minute timeout)
+  if (await _chrome.offscreen.hasDocument()) return
+
+  try {
+    await _chrome.offscreen.createDocument({
+      url: 'src/offscreen.html',
+      reasons: ['BLOBS'],
+      justification: 'Keep service worker alive for heartbeat packets',
+    })
+  } catch (e) {
+    console.error('Failed to create offscreen document:', e)
   }
-
-  // Start the keep-alive mechanism
-  setupKeepAlive()
 }
+
+browser.runtime.onMessage.addListener((message: any) => {
+  if (message.type === 'KEEP_ALIVE') {
+    return Promise.resolve({ status: 'ok' })
+  }
+  return undefined
+})
+
+// Initialize on startup and installation
+browser.runtime.onStartup.addListener(setupOffscreen)
+browser.runtime.onInstalled.addListener(setupOffscreen)
+
+setupOffscreen()

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -48,6 +48,7 @@
         "alarms",
         "notifications",
         "activeTab",
+        "offscreen",
         "storage"
     ],
     "{{safari}}.permissions": [

--- a/src/offscreen.html
+++ b/src/offscreen.html
@@ -1,0 +1,9 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset="UTF-8" />
+  </head>
+  <body>
+    <script type="module" src="./offscreen.ts"></script>
+  </body>
+</html>

--- a/src/offscreen.ts
+++ b/src/offscreen.ts
@@ -1,0 +1,11 @@
+import browser from 'webextension-polyfill'
+
+// Send a message to the background every 20 seconds to keep the Service Worker alive
+function keepAlive() {
+  browser.runtime.sendMessage({ type: 'KEEP_ALIVE' }).catch(() => {
+    // Expected during reload
+  })
+}
+
+setInterval(keepAlive, 20 * 1000)
+keepAlive()

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -20,7 +20,11 @@ export default defineConfig({
   plugins: [
     webExtension({
       manifest: generateManifest,
-      additionalInputs: ['src/consent/index.html', 'src/consent/main.ts'],
+      additionalInputs: [
+        'src/consent/index.html',
+        'src/consent/main.ts',
+        'src/offscreen.html',
+      ],
       browser: process.env.VITE_TARGET_BROWSER,
     }),
   ],


### PR DESCRIPTION
https://github.com/Tokisaki-Galaxy/aw-watcher-web/actions
Passed the action compilation and grammar check, and has been tested to be normal.
resolve https://github.com/ActivityWatch/aw-watcher-web/issues/199

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Implements Offscreen API in Chrome to keep the service worker alive by adding offscreen document and periodic messaging.
> 
>   - **Behavior**:
>     - Implements `setupOffscreen()` in `main.ts` to keep the service worker alive using the Offscreen API for Chrome.
>     - Sends periodic `KEEP_ALIVE` messages from `offscreen.ts` to prevent service worker termination.
>     - Listens for `KEEP_ALIVE` messages in `main.ts` and responds with status 'ok'.
>   - **Files**:
>     - Adds `offscreen.html` to load `offscreen.ts`.
>     - Adds `offscreen.ts` to send periodic messages to the background script.
>   - **Configuration**:
>     - Updates `manifest.json` to include `offscreen` permission for Chrome.
>     - Updates `vite.config.ts` to include `src/offscreen.html` in `additionalInputs`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ActivityWatch%2Faw-watcher-web&utm_source=github&utm_medium=referral)<sup> for 712cbab03c13e1de64f88d395a9a29b8b4643054. You can [customize](https://app.ellipsis.dev/ActivityWatch/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->