### PR TITLE
fix: limit retries when calling ensureBucket

### DIFF
--- a/src/background/client.ts
+++ b/src/background/client.ts
@@ -24,7 +24,7 @@ export function ensureBucket(
           logHttpError(err)
           return Promise.reject(err)
         }),
-    { forever: true, minTimeout: 500 },
+    { retries: 3, minTimeout: 500 },
   )
 }
 

--- a/src/background/client.ts
+++ b/src/background/client.ts
@@ -74,7 +74,7 @@ export async function sendHeartbeat(
     {
       retries: 3,
       onFailedAttempt: () =>
-        ensureBucket(client, bucketId, hostname).then(() => {}),
+        ensureBucket(client, bucketId, hostname).catch(() => {}),
     },
   )
     .then(() => {


### PR DESCRIPTION
When wrapping a call to client.ensureBucket with p-retry, passing `forever: true` may have caused issues such as #176 and #60 , for users whose ActivityWatch server is not reachable, since every new `heartbeat()` calls a new `ensureBucket()`, resulting in 60 concurrent calls an hour after the user opens their browser, and considerably more after a few days.

As a side-effect, removes [deprecated](https://github.com/sindresorhus/p-retry/blob/35681f6c70f8ca2bdcb9542281147679184269fa/index.js#L201-L203) p-retry `forever`.

If I understand correctly, every 60s the onAlarm listener; heartbeatAlarmListener is called, which in turn awaits the heartbeat function, which in turn calls sendHeartbeat, which retries 3x and onFailedAttempt calls ensureBucket.

What I haven't thought through fully is whether this means a browser notification to inform the user "Unable to send event to server", "Please ensure that ActivityWatch is running" is never sent, as perhaps in that scenario, `ensureHeartbeat` simply retries forever instead?

Replacing `forever: true` with three retries before giving up, as every 60s `heartbeatAlarmListener` will be called regardless, if I understand correctly?