### PR TITLE
fix: prevent favicon data retention in heartbeat debug logs

### DIFF
--- a/src/background/heartbeat.ts
+++ b/src/background/heartbeat.ts
@@ -27,17 +27,22 @@ async function heartbeat(
     return
   }
 
+  // Extract only the fields we need so we don't retain references to the
+  // full Tab object (which includes favIconUrl — a potentially large base64
+  // data URI).  Over thousands of heartbeats the retained Tab references
+  // cause unbounded memory growth (see #222).
+  const { url, title, audible, incognito } = tab
   const now = new Date()
   const data: IEvent['data'] = {
-    url: tab.url,
-    title: tab.title,
-    audible: tab.audible ?? false,
-    incognito: tab.incognito,
+    url,
+    title,
+    audible: audible ?? false,
+    incognito,
     tabCount: tabCount,
   }
   const previousData = await getHeartbeatData()
   if (previousData && !deepEqual(previousData, data)) {
-    console.debug('Sending heartbeat for previous data', previousData)
+    console.debug('Sending heartbeat for previous data')
     await sendHeartbeat(
       client,
       await getBucketId(),
@@ -46,7 +51,7 @@ async function heartbeat(
       config.heartbeat.intervalInSeconds + 20,
     )
   }
-  console.debug('Sending heartbeat', data)
+  console.debug('Sending heartbeat', url)
   await sendHeartbeat(
     client,
     await getBucketId(),
@@ -60,7 +65,7 @@ async function heartbeat(
 export const sendInitialHeartbeat = async (client: AWClient) => {
   const activeWindowTab = await getActiveWindowTab()
   const tabs = await getTabs()
-  console.debug('Sending initial heartbeat', activeWindowTab)
+  console.debug('Sending initial heartbeat', activeWindowTab?.url)
   await heartbeat(client, activeWindowTab, tabs.length)
 }
 
@@ -70,7 +75,7 @@ export const heartbeatAlarmListener =
     const activeWindowTab = await getActiveWindowTab()
     if (!activeWindowTab) return
     const tabs = await getTabs()
-    console.debug('Sending heartbeat for alarm', activeWindowTab)
+    console.debug('Sending heartbeat for alarm', activeWindowTab.url)
     await heartbeat(client, activeWindowTab, tabs.length)
   }
 
@@ -79,6 +84,6 @@ export const tabActivatedListener =
   async (activeInfo: browser.Tabs.OnActivatedActiveInfoType) => {
     const tab = await getTab(activeInfo.tabId)
     const tabs = await getTabs()
-    console.debug('Sending heartbeat for tab activation', tab)
+    console.debug('Sending heartbeat for tab activation', tab.url)
     await heartbeat(client, tab, tabs.length)
   }

--- a/src/background/heartbeat.ts
+++ b/src/background/heartbeat.ts
@@ -42,7 +42,7 @@ async function heartbeat(
   }
   const previousData = await getHeartbeatData()
   if (previousData && !deepEqual(previousData, data)) {
-    console.debug('Sending heartbeat for previous data')
+    console.debug('Sending heartbeat for previous data', previousData)
     await sendHeartbeat(
       client,
       await getBucketId(),
@@ -51,7 +51,7 @@ async function heartbeat(
       config.heartbeat.intervalInSeconds + 20,
     )
   }
-  console.debug('Sending heartbeat', url)
+  console.debug('Sending heartbeat', data)
   await sendHeartbeat(
     client,
     await getBucketId(),


### PR DESCRIPTION
## Problem

The heartbeat module passes entire `Tab` objects to `console.debug()`. In Firefox, `Tab.favIconUrl` is a base64 data URI (often 10-20 KB). Browser console buffers retain references to logged objects, so over thousands of heartbeats the retained `Tab` references accumulate hundreds of MBs of duplicate favicon data in memory.

From the `about:memory` report in #222:
- **~761 MB of strings** — all base64-encoded favicon/icon data
- One favicon: 8,804 copies × ~22 KB each = 189 MB
- Another: 17,426 copies × ~9 KB each = 157 MB

## Fix

1. **Destructure tab early**: Extract only `url`, `title`, `audible`, `incognito` from the `Tab` object, so the full object (including `favIconUrl`) can be GC'd immediately
2. **Log only URL strings**: Replace `console.debug('...', tab)` with `console.debug('...', tab.url)` — retains useful debug info without retaining the full object

This is the **favicon half** of #222. The AbortController leak (the other half, ~123 MB of leaked controllers + ~645 MB of closures) is being addressed in aw-client-js via ActivityWatch/aw-client-js#50.

## Test plan

- [ ] Build passes (`npm run build`)
- [ ] Extension loads in Firefox/Chrome and sends heartbeats normally
- [ ] After extended use, `about:memory` no longer shows large favicon string accumulation under the extension's background page