### PR TITLE
fix(detect): auto-detect Zen/Floorp via getBrowserInfo (fixes #232)

### DIFF
--- a/src/background/helpers.ts
+++ b/src/background/helpers.ts
@@ -2,6 +2,36 @@ import browser from 'webextension-polyfill'
 import { FetchError } from 'aw-client'
 import { getBrowserName, setBrowserName } from '../storage'
 
+// Firefox forks share Firefox's userAgent (that's how they run Firefox
+// extensions unchanged), so UA-based detection cannot distinguish them.
+// browser.runtime.getBrowserInfo() is a Firefox-only API that returns
+// {name, vendor, version, buildID} and is overridden by most forks to
+// reflect their own brand. We use it to refine 'firefox' into a specific
+// fork name when aw-webui's queries.ts has a dedicated entry for it
+// (browser_appnames + browser_appname_regex). Forks not listed below
+// (librewolf, waterfox, …) fall through and keep using the firefox bucket,
+// which already covers them via the firefox regex.
+const FIREFOX_FORK_BUCKETS: Record<string, string> = {
+  zen: 'zen',
+  floorp: 'floorp',
+}
+
+async function refineFirefoxFork(): Promise<string> {
+  // getBrowserInfo is Firefox-only; missing on Chromium and on Firefox < 51.
+  const getBrowserInfo = (browser.runtime as any).getBrowserInfo
+  if (typeof getBrowserInfo !== 'function') return 'firefox'
+  try {
+    const info = await getBrowserInfo.call(browser.runtime)
+    const name = (info?.name || '').toLowerCase()
+    for (const key of Object.keys(FIREFOX_FORK_BUCKETS)) {
+      if (name.includes(key)) return FIREFOX_FORK_BUCKETS[key]
+    }
+    return 'firefox'
+  } catch {
+    return 'firefox'
+  }
+}
+
 export const getTab = (id: number) => browser.tabs.get(id)
 export const getTabs = (query: browser.Tabs.QueryQueryInfoType = {}) =>
   browser.tabs.query(query)
@@ -48,7 +78,11 @@ export const getBrowser = async (): Promise<string> => {
     return storedName
   }
 
-  const browserName = detectBrowser()
+  let browserName = detectBrowser()
+  // Refine Firefox-family detection so forks like Zen get their own bucket.
+  if (browserName === 'firefox') {
+    browserName = await refineFirefoxFork()
+  }
 
   await setBrowserName(browserName)
   return browserName


### PR DESCRIPTION
Fixes #232.

`detectBrowser()` only looks at `navigator.userAgent`, which is plain Firefox for Firefox forks (Zen, Floorp, LibreWolf, Waterfox, …) since that's how they run Firefox extensions unchanged. As a result, Zen users end up with a bucket named `aw-watcher-web-firefox_<host>`, but aw-webui's Browser view filters window events through the firefox regex `(?i)(firefox|librewolf|waterfox|nightly)`. Zen's window-watcher `app` name doesn't match, so "Top Browser Domains/URLs" comes up empty even though the raw events show up in Timeline.

This refines the `firefox` branch with `browser.runtime.getBrowserInfo()` — a Firefox-only API that forks override to report their own name — and maps forks that have a dedicated entry in aw-webui's `queries.ts` (`browser_appnames` + `browser_appname_regex`) onto their own bucket: currently `zen` and `floorp`. Forks without a dedicated entry (librewolf, waterfox) fall through and keep the firefox bucket, which already covers them via the firefox regex.

`getBrowserInfo` is absent on Chromium and on Firefox < 51, so the lookup is guarded with a `typeof` check and a try/catch and falls back to `'firefox'` on anything unexpected.

Notes:
- Only touches the first-time auto-detect path (`storedName` short-circuits as before, so existing installs keep their current bucket — no migration, no data loss).
- Users already on the firefox bucket can switch over via Settings → Browser → Zen (the dropdown entry already exists), or just reinstall the extension.
- No new dependencies, no API changes outside `helpers.ts`. `tsc --noEmit` and `vite build` both clean.
