### PR TITLE
feat(settings): add API key field for Bearer token auth

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,7 +7,7 @@
             "name": "aw-watcher-web",
             "license": "MPL-2.0",
             "dependencies": {
-                "aw-client": "^0.4.1",
+                "aw-client": "github:ActivityWatch/aw-client-js#6093fbb10c2721510515c93ae7f85b9bc6210eda",
                 "deep-equal": "^2.2.3",
                 "p-retry": "^6.2.1",
                 "webextension-polyfill": "^0.12.0"
@@ -720,8 +720,8 @@
         },
         "node_modules/aw-client": {
             "version": "0.4.1",
-            "resolved": "https://registry.npmjs.org/aw-client/-/aw-client-0.4.1.tgz",
-            "integrity": "sha512-XTonpbduirGJTxFQt3/QXtN8L9i/GlOzp3gEBEzdr7a7Ot9pnn71QgnJU66KkPy9EMKZlA2d6DQh9wSA3cuePQ==",
+            "resolved": "git+ssh://git@github.com/ActivityWatch/aw-client-js.git#6093fbb10c2721510515c93ae7f85b9bc6210eda",
+            "integrity": "sha512-oey7kw3+EELkryIersx8j/FKkezcnCQ/Y8UwKRrYqJT1krQu8qUcxHqKfvI+BZHhm/m9mFPJnXZUgEO+KHxDtA==",
             "license": "MPL-2.0"
         },
         "node_modules/balanced-match": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,7 +7,7 @@
             "name": "aw-watcher-web",
             "license": "MPL-2.0",
             "dependencies": {
-                "aw-client": "github:ActivityWatch/aw-client-js#6093fbb10c2721510515c93ae7f85b9bc6210eda",
+                "aw-client": "git+https://github.com/ActivityWatch/aw-client-js.git#6093fbb10c2721510515c93ae7f85b9bc6210eda",
                 "deep-equal": "^2.2.3",
                 "p-retry": "^6.2.1",
                 "webextension-polyfill": "^0.12.0"
@@ -720,7 +720,7 @@
         },
         "node_modules/aw-client": {
             "version": "0.4.1",
-            "resolved": "git+ssh://git@github.com/ActivityWatch/aw-client-js.git#6093fbb10c2721510515c93ae7f85b9bc6210eda",
+            "resolved": "git+https://github.com/ActivityWatch/aw-client-js.git#6093fbb10c2721510515c93ae7f85b9bc6210eda",
             "integrity": "sha512-oey7kw3+EELkryIersx8j/FKkezcnCQ/Y8UwKRrYqJT1krQu8qUcxHqKfvI+BZHhm/m9mFPJnXZUgEO+KHxDtA==",
             "license": "MPL-2.0"
         },

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
         "url": "git+https://github.com/ActivityWatch/aw-watcher-web.git"
     },
     "dependencies": {
-        "aw-client": "^0.4.1",
+        "aw-client": "github:ActivityWatch/aw-client-js#6093fbb10c2721510515c93ae7f85b9bc6210eda",
         "deep-equal": "^2.2.3",
         "p-retry": "^6.2.1",
         "webextension-polyfill": "^0.12.0"

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
         "url": "git+https://github.com/ActivityWatch/aw-watcher-web.git"
     },
     "dependencies": {
-        "aw-client": "github:ActivityWatch/aw-client-js#6093fbb10c2721510515c93ae7f85b9bc6210eda",
+        "aw-client": "git+https://github.com/ActivityWatch/aw-client-js.git#6093fbb10c2721510515c93ae7f85b9bc6210eda",
         "deep-equal": "^2.2.3",
         "p-retry": "^6.2.1",
         "webextension-polyfill": "^0.12.0"

--- a/src/background/client.ts
+++ b/src/background/client.ts
@@ -3,10 +3,20 @@ import config from '../config'
 import { AWClient, IEvent } from 'aw-client'
 import retry from 'p-retry'
 import { emitNotification, getBrowser, logHttpError } from './helpers'
-import { getHostname, getSyncStatus, setSyncStatus } from '../storage'
+import {
+  getApiKey,
+  getHostname,
+  getSyncStatus,
+  setSyncStatus,
+} from '../storage'
 
-export const getClient = () =>
-  new AWClient('aw-client-web', { testing: config.isDevelopment })
+export const getClient = async () => {
+  const apiKey = await getApiKey()
+  return new AWClient('aw-client-web', {
+    testing: config.isDevelopment,
+    ...(apiKey ? { token: apiKey } : {}),
+  })
+}
 
 // TODO: We might want to get the hostname somehow, maybe like this:
 // https://stackoverflow.com/questions/28223087/how-can-i-allow-firefox-or-chrome-to-read-a-pcs-hostname-or-other-assignable
@@ -39,7 +49,9 @@ export async function detectHostname(client: AWClient) {
       retries: 3,
       onFailedAttempt: (error) => {
         console.warn(
-          `Failed to detect hostname (attempt ${error.attemptNumber}/${error.retriesLeft + error.attemptNumber}):`,
+          `Failed to detect hostname (attempt ${error.attemptNumber}/${
+            error.retriesLeft + error.attemptNumber
+          }):`,
           error.message,
         )
       },

--- a/src/background/client.ts
+++ b/src/background/client.ts
@@ -10,12 +10,11 @@ import {
   setSyncStatus,
 } from '../storage'
 
-export const getClient = async () => {
-  const apiKey = await getApiKey()
-  return new AWClient('aw-client-web', {
-    testing: config.isDevelopment,
-    ...(apiKey ? { token: apiKey } : {}),
-  })
+export const getClient = () =>
+  new AWClient('aw-client-web', { testing: config.isDevelopment })
+
+export const loadApiKey = async (client: AWClient) => {
+  client.token = await getApiKey()
 }
 
 // TODO: We might want to get the hostname somehow, maybe like this:

--- a/src/background/main.ts
+++ b/src/background/main.ts
@@ -5,7 +5,7 @@ import {
   sendInitialHeartbeat,
   tabActivatedListener,
 } from './heartbeat'
-import { getClient, detectHostname } from './client'
+import { getClient, detectHostname, loadApiKey } from './client'
 import {
   getConsentStatus,
   getHostname,
@@ -24,9 +24,7 @@ async function getIsConsentRequired() {
     .catch(() => true)
 }
 
-async function autodetectHostname(
-  client: Awaited<ReturnType<typeof getClient>>,
-) {
+async function autodetectHostname(client: ReturnType<typeof getClient>) {
   const hostname = await getHostname()
   if (hostname === undefined) {
     const detectedHostname = await detectHostname(client)
@@ -39,46 +37,54 @@ async function autodetectHostname(
 /** Init */
 console.info('Starting...')
 
-async function init() {
-  console.debug('Creating client')
-  const client = await getClient()
+console.debug('Creating client')
+const client = getClient()
+const clientReady = loadApiKey(client)
 
-  browser.runtime.onInstalled.addListener(async () => {
-    const { consent } = await getConsentStatus()
-    const isConsentRequired = await getIsConsentRequired()
-    if (!isConsentRequired || consent) {
-      if (!isConsentRequired) console.info('Consent is not required')
-      else if (consent) console.info('Consent required but already accepted')
-      console.debug('Enabling the extension')
-      await setEnabled(true)
-    } else {
-      console.info('Consent is required...opening consent tab')
-      await setConsentStatus({ consent, required: true })
-      await browser.tabs.create({
-        active: true,
-        url: browser.runtime.getURL('src/consent/index.html'),
-      })
-    }
+browser.runtime.onInstalled.addListener(async () => {
+  const { consent } = await getConsentStatus()
+  const isConsentRequired = await getIsConsentRequired()
+  if (!isConsentRequired || consent) {
+    if (!isConsentRequired) console.info('Consent is not required')
+    else if (consent) console.info('Consent required but already accepted')
+    console.debug('Enabling the extension')
+    await setEnabled(true)
+  } else {
+    console.info('Consent is required...opening consent tab')
+    await setConsentStatus({ consent, required: true })
+    await browser.tabs.create({
+      active: true,
+      url: browser.runtime.getURL('src/consent/index.html'),
+    })
+  }
 
-    await autodetectHostname(client)
-  })
+  await clientReady
+  await autodetectHostname(client)
+})
 
-  console.debug('Creating alarms and tab listeners')
-  browser.alarms.create(config.heartbeat.alarmName, {
-    periodInMinutes: Math.floor(config.heartbeat.intervalInSeconds / 60),
-  })
-  browser.alarms.onAlarm.addListener(heartbeatAlarmListener(client))
-  browser.tabs.onActivated.addListener(tabActivatedListener(client))
+console.debug('Creating alarms and tab listeners')
+browser.alarms.create(config.heartbeat.alarmName, {
+  periodInMinutes: Math.floor(config.heartbeat.intervalInSeconds / 60),
+})
+browser.alarms.onAlarm.addListener(async (alarm) => {
+  await clientReady
+  return heartbeatAlarmListener(client)(alarm)
+})
+browser.tabs.onActivated.addListener(async (activeInfo) => {
+  await clientReady
+  return tabActivatedListener(client)(activeInfo)
+})
 
-  console.debug('Setting base url')
-  await setBaseUrl(client.baseURL)
-  console.debug('Waiting for enable before sending initial heartbeat')
-  await waitForEnabled()
-  await sendInitialHeartbeat(client)
-  console.info('Started successfully')
-}
-
-init().catch((err) => console.error('Failed to initialize extension:', err))
+console.debug('Setting base url')
+clientReady
+  .then(() => setBaseUrl(client.baseURL))
+  .then(() =>
+    console.debug('Waiting for enable before sending initial heartbeat'),
+  )
+  .then(waitForEnabled)
+  .then(() => sendInitialHeartbeat(client))
+  .then(() => console.info('Started successfully'))
+  .catch((err) => console.error('Failed to initialize extension:', err))
 
 /**
  * Keep the service worker alive using Offscreen API to prevent Chrome's termination.

--- a/src/background/main.ts
+++ b/src/background/main.ts
@@ -24,7 +24,9 @@ async function getIsConsentRequired() {
     .catch(() => true)
 }
 
-async function autodetectHostname() {
+async function autodetectHostname(
+  client: Awaited<ReturnType<typeof getClient>>,
+) {
   const hostname = await getHostname()
   if (hostname === undefined) {
     const detectedHostname = await detectHostname(client)
@@ -37,44 +39,46 @@ async function autodetectHostname() {
 /** Init */
 console.info('Starting...')
 
-console.debug('Creating client')
-const client = getClient()
+async function init() {
+  console.debug('Creating client')
+  const client = await getClient()
 
-browser.runtime.onInstalled.addListener(async () => {
-  const { consent } = await getConsentStatus()
-  const isConsentRequired = await getIsConsentRequired()
-  if (!isConsentRequired || consent) {
-    if (!isConsentRequired) console.info('Consent is not required')
-    else if (consent) console.info('Consent required but already accepted')
-    console.debug('Enabling the extension')
-    await setEnabled(true)
-  } else {
-    console.info('Consent is required...opening consent tab')
-    await setConsentStatus({ consent, required: true })
-    await browser.tabs.create({
-      active: true,
-      url: browser.runtime.getURL('src/consent/index.html'),
-    })
-  }
+  browser.runtime.onInstalled.addListener(async () => {
+    const { consent } = await getConsentStatus()
+    const isConsentRequired = await getIsConsentRequired()
+    if (!isConsentRequired || consent) {
+      if (!isConsentRequired) console.info('Consent is not required')
+      else if (consent) console.info('Consent required but already accepted')
+      console.debug('Enabling the extension')
+      await setEnabled(true)
+    } else {
+      console.info('Consent is required...opening consent tab')
+      await setConsentStatus({ consent, required: true })
+      await browser.tabs.create({
+        active: true,
+        url: browser.runtime.getURL('src/consent/index.html'),
+      })
+    }
 
-  await autodetectHostname()
-})
+    await autodetectHostname(client)
+  })
 
-console.debug('Creating alarms and tab listeners')
-browser.alarms.create(config.heartbeat.alarmName, {
-  periodInMinutes: Math.floor(config.heartbeat.intervalInSeconds / 60),
-})
-browser.alarms.onAlarm.addListener(heartbeatAlarmListener(client))
-browser.tabs.onActivated.addListener(tabActivatedListener(client))
+  console.debug('Creating alarms and tab listeners')
+  browser.alarms.create(config.heartbeat.alarmName, {
+    periodInMinutes: Math.floor(config.heartbeat.intervalInSeconds / 60),
+  })
+  browser.alarms.onAlarm.addListener(heartbeatAlarmListener(client))
+  browser.tabs.onActivated.addListener(tabActivatedListener(client))
 
-console.debug('Setting base url')
-setBaseUrl(client.baseURL)
-  .then(() =>
-    console.debug('Waiting for enable before sending initial heartbeat'),
-  )
-  .then(waitForEnabled)
-  .then(() => sendInitialHeartbeat(client))
-  .then(() => console.info('Started successfully'))
+  console.debug('Setting base url')
+  await setBaseUrl(client.baseURL)
+  console.debug('Waiting for enable before sending initial heartbeat')
+  await waitForEnabled()
+  await sendInitialHeartbeat(client)
+  console.info('Started successfully')
+}
+
+init().catch((err) => console.error('Failed to initialize extension:', err))
 
 /**
  * Keep the service worker alive using Offscreen API to prevent Chrome's termination.

--- a/src/settings/index.html
+++ b/src/settings/index.html
@@ -52,6 +52,23 @@
       </div>
 
       <div>
+        <label for="apiKey">
+          <strong>API Key:</strong>
+        </label>
+
+        <input
+          type="password"
+          id="apiKey"
+          name="apiKey"
+          placeholder="Leave blank if auth is disabled"
+        />
+        <small
+          >Found in <code>aw-server-rust/config.toml</code> under
+          <code>[auth] api_key</code></small
+        >
+      </div>
+
+      <div>
         <button type="submit">Save</button>
       </div>
     </form>

--- a/src/settings/main.ts
+++ b/src/settings/main.ts
@@ -114,6 +114,7 @@ async function restoreOptions(): Promise<void> {
     }
   } catch (error) {
     console.error('Failed to restore options:', error)
+    throw error
   }
 }
 
@@ -126,8 +127,13 @@ async function initializeOptions(): Promise<void> {
   try {
     await restoreOptions()
     optionsReady = true
-  } finally {
     if (button) button.disabled = false
+  } catch (error) {
+    console.error('Failed to initialize options:', error)
+    if (button) {
+      button.textContent = 'Error loading settings'
+      button.classList.add('error')
+    }
   }
 }
 

--- a/src/settings/main.ts
+++ b/src/settings/main.ts
@@ -82,27 +82,25 @@ async function restoreOptions(): Promise<void> {
     const customInput =
       document.querySelector<HTMLInputElement>('#customBrowser')
 
-    if (!browserSelect || !customInput || !browserName) return
-
-    const standardBrowsers = Array.from(browserSelect.options).map(
-      (opt) => opt.value,
-    )
-    if (!standardBrowsers.includes(browserName)) {
-      browserSelect.value = 'other'
-      customInput.style.display = 'block'
-      customInput.value = browserName
-      customInput.required = true
-    } else {
-      browserSelect.value = browserName
-      customInput.style.display = 'none'
-      customInput.required = false
+    if (browserSelect && customInput && browserName) {
+      const standardBrowsers = Array.from(browserSelect.options).map(
+        (opt) => opt.value,
+      )
+      if (!standardBrowsers.includes(browserName)) {
+        browserSelect.value = 'other'
+        customInput.style.display = 'block'
+        customInput.value = browserName
+        customInput.required = true
+      } else {
+        browserSelect.value = browserName
+        customInput.style.display = 'none'
+        customInput.required = false
+      }
     }
 
     const hostname = await getHostname()
     const hostnameInput = document.querySelector<HTMLInputElement>('#hostname')
-    if (!hostnameInput) return
-
-    if (hostname !== undefined) {
+    if (hostnameInput && hostname !== undefined) {
       hostnameInput.value = hostname
     }
 

--- a/src/settings/main.ts
+++ b/src/settings/main.ts
@@ -1,9 +1,11 @@
 import browser from 'webextension-polyfill'
 import {
+  getApiKey,
   getBrowserName,
   setBrowserName,
   getHostname,
   setHostname,
+  setApiKey,
 } from '../storage'
 import { detectBrowser } from '../background/helpers'
 
@@ -34,6 +36,9 @@ async function saveOptions(e: SubmitEvent): Promise<void> {
 
   const hostname = hostnameInput.value
 
+  const apiKeyInput = document.querySelector<HTMLInputElement>('#apiKey')
+  const apiKey = apiKeyInput?.value?.trim() ?? ''
+
   const form = e.target as HTMLFormElement
   const button = form.querySelector<HTMLButtonElement>('button')
   if (!button) return
@@ -44,6 +49,11 @@ async function saveOptions(e: SubmitEvent): Promise<void> {
   try {
     await setBrowserName(selectedBrowser)
     await setHostname(hostname)
+    if (apiKey) {
+      await setApiKey(apiKey)
+    } else {
+      await browser.storage.local.remove('apiKey')
+    }
     await reloadExtension()
     button.textContent = 'Save'
     button.classList.add('accept')
@@ -94,6 +104,12 @@ async function restoreOptions(): Promise<void> {
 
     if (hostname !== undefined) {
       hostnameInput.value = hostname
+    }
+
+    const apiKey = await getApiKey()
+    const apiKeyInput = document.querySelector<HTMLInputElement>('#apiKey')
+    if (apiKeyInput && apiKey !== undefined) {
+      apiKeyInput.value = apiKey
     }
   } catch (error) {
     console.error('Failed to restore options:', error)

--- a/src/settings/main.ts
+++ b/src/settings/main.ts
@@ -9,6 +9,8 @@ import {
 } from '../storage'
 import { detectBrowser } from '../background/helpers'
 
+let optionsReady = false
+
 async function reloadExtension(): Promise<void> {
   browser.runtime.reload()
 
@@ -20,6 +22,7 @@ async function reloadExtension(): Promise<void> {
 
 async function saveOptions(e: SubmitEvent): Promise<void> {
   e.preventDefault()
+  if (!optionsReady) return
 
   const browserSelect = document.querySelector<HTMLSelectElement>('#browser')
   const customBrowserInput =
@@ -114,8 +117,22 @@ async function restoreOptions(): Promise<void> {
   }
 }
 
+async function initializeOptions(): Promise<void> {
+  const button = document.querySelector<HTMLButtonElement>(
+    'button[type="submit"]',
+  )
+  if (button) button.disabled = true
+
+  try {
+    await restoreOptions()
+    optionsReady = true
+  } finally {
+    if (button) button.disabled = false
+  }
+}
+
 document.addEventListener('DOMContentLoaded', () => {
-  restoreOptions()
+  void initializeOptions()
   toggleCustomBrowserInput()
 })
 

--- a/src/storage.ts
+++ b/src/storage.ts
@@ -101,3 +101,11 @@ export const getHostname = (): Promise<Hostname | undefined> =>
     .then((data: StorageData) => data.hostname as string | undefined)
 export const setHostname = (hostname: Hostname) =>
   browser.storage.local.set({ hostname })
+
+type ApiKey = string
+export const getApiKey = (): Promise<ApiKey | undefined> =>
+  browser.storage.local
+    .get('apiKey')
+    .then((data: StorageData) => data.apiKey as string | undefined)
+export const setApiKey = (apiKey: ApiKey) =>
+  browser.storage.local.set({ apiKey })


### PR DESCRIPTION
## Summary

Lets users enter their ActivityWatch API key in the extension Settings page.
When set, the extension passes it to `AWClient` so all heartbeats include
`Authorization: Bearer <key>`.

This is needed for users who enable API authentication on their local
aw-server-rust instance (ActivityWatch/activitywatch#1199).

## Changes

- **storage.ts**: `getApiKey` / `setApiKey` helpers (browser.storage.local)
- **client.ts**: `getClient()` is now `async`; reads the stored API key and
  passes it as `{ token }` to `AWClient` (requires ActivityWatch/aw-client-js#52)
- **settings/index.html**: password-type "API Key" field with a hint pointing
  to the config file location; leave blank to disable auth
- **settings/main.ts**: saves/clears the key on form submit, restores it on
  page load
- **main.ts**: refactored top-level init into an `async function init()` so
  `await getClient()` works; `autodetectHostname` now takes `client` as a
  parameter to avoid the old module-level reference

## Dependency

Requires ActivityWatch/aw-client-js#52 to be merged and the `aw-client`
package bumped in package.json before this lands.

## Test plan

- [ ] With auth disabled on server: leave API Key blank → extension tracks as before
- [ ] With auth enabled: enter API key from config.toml → heartbeats succeed (no 401s)
- [ ] Wrong key → extension shows "Unable to send event" notification as before
- [ ] Save with empty key → key cleared from storage → auth header removed

Closes part of ActivityWatch/activitywatch#1199.