### PR TITLE
Decode punycode domains to Unicode

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
                 "aw-client": "git+https://github.com/ActivityWatch/aw-client-js.git#6093fbb10c2721510515c93ae7f85b9bc6210eda",
                 "deep-equal": "^2.2.3",
                 "p-retry": "^6.2.1",
+                "punycode.js": "^2.3.1",
                 "webextension-polyfill": "^0.12.0"
             },
             "devDependencies": {
@@ -3097,6 +3098,15 @@
             "integrity": "sha512-vtK/94akxsTMhe0/cbfpR+syPuszcuwhqVjJq26CuNDgFGj682oRBXOP5MJpv2r7JtE8MsiepGIqvvOTBwn2vA==",
             "dev": true,
             "license": "ISC"
+        },
+        "node_modules/punycode.js": {
+            "version": "2.3.1",
+            "resolved": "https://registry.npmjs.org/punycode.js/-/punycode.js-2.3.1.tgz",
+            "integrity": "sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=6"
+            }
         },
         "node_modules/pupa": {
             "version": "3.3.0",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
         "aw-client": "git+https://github.com/ActivityWatch/aw-client-js.git#6093fbb10c2721510515c93ae7f85b9bc6210eda",
         "deep-equal": "^2.2.3",
         "p-retry": "^6.2.1",
+        "punycode.js": "^2.3.1",
         "webextension-polyfill": "^0.12.0"
     },
     "devDependencies": {

--- a/src/background/heartbeat.ts
+++ b/src/background/heartbeat.ts
@@ -5,6 +5,39 @@ import { AWClient, IEvent } from 'aw-client'
 import { getBucketId, sendHeartbeat } from './client'
 import { getEnabled, getHeartbeatData, setHeartbeatData } from '../storage'
 import deepEqual from 'deep-equal'
+import * as punycode from 'punycode.js'
+
+function decodeURL(url: string): string {
+  try {
+    const parsed = new URL(url)
+    const hostname = parsed.hostname
+    if (!hostname.includes('xn--')) {
+      return url
+    }
+
+    // URL.hostname assignment converts Unicode back to punycode, so swap
+    // the hostname in the original string instead of using the URL setter.
+    const decodedHostname = punycode.toUnicode(hostname)
+    const hostnameOffset = url.toLowerCase().indexOf(hostname)
+    if (hostnameOffset === -1) {
+      const userinfo =
+        parsed.username === ''
+          ? ''
+          : `${parsed.username}${parsed.password === '' ? '' : `:${parsed.password}`}@`
+      const port = parsed.port === '' ? '' : `:${parsed.port}`
+      return `${parsed.protocol}//${userinfo}${decodedHostname}${port}${parsed.pathname}${parsed.search}${parsed.hash}`
+    }
+
+    return (
+      url.slice(0, hostnameOffset) +
+      decodedHostname +
+      url.slice(hostnameOffset + hostname.length)
+    )
+  } catch (e) {
+    console.error('Error decoding URL:', e)
+    return url
+  }
+}
 
 function formatHeartbeatLogData(data: IEvent['data']) {
   return Object.entries(data)
@@ -48,7 +81,7 @@ async function heartbeat(
   const { url, title, audible, incognito } = tab
   const now = new Date()
   const data: IEvent['data'] = {
-    url,
+    url: decodeURL(url),
     title,
     audible: audible ?? false,
     incognito,

--- a/src/background/heartbeat.ts
+++ b/src/background/heartbeat.ts
@@ -10,29 +10,24 @@ import * as punycode from 'punycode.js'
 function decodeURL(url: string): string {
   try {
     const parsed = new URL(url)
-    const hostname = parsed.hostname
-    if (!hostname.includes('xn--')) {
+    if (!parsed.hostname.includes('xn--')) {
       return url
     }
 
-    // URL.hostname assignment converts Unicode back to punycode, so swap
-    // the hostname in the original string instead of using the URL setter.
-    const decodedHostname = punycode.toUnicode(hostname)
-    const hostnameOffset = url.toLowerCase().indexOf(hostname)
-    if (hostnameOffset === -1) {
-      const userinfo =
-        parsed.username === ''
-          ? ''
-          : `${parsed.username}${parsed.password === '' ? '' : `:${parsed.password}`}@`
-      const port = parsed.port === '' ? '' : `:${parsed.port}`
-      return `${parsed.protocol}//${userinfo}${decodedHostname}${port}${parsed.pathname}${parsed.search}${parsed.hash}`
-    }
-
-    return (
-      url.slice(0, hostnameOffset) +
-      decodedHostname +
-      url.slice(hostnameOffset + hostname.length)
-    )
+    // Do not assign parsed.hostname — the setter converts Unicode back to
+    // punycode. Rebuild from parsed parts so userinfo is never mistaken
+    // for the hostname.
+    const decodedHost = punycode.toUnicode(parsed.hostname)
+    const userinfo =
+      parsed.username === ''
+        ? ''
+        : `${encodeURIComponent(parsed.username)}${
+            parsed.password === ''
+              ? ''
+              : `:${encodeURIComponent(parsed.password)}`
+          }@`
+    const port = parsed.port === '' ? '' : `:${parsed.port}`
+    return `${parsed.protocol}//${userinfo}${decodedHost}${port}${parsed.pathname}${parsed.search}${parsed.hash}`
   } catch (e) {
     console.error('Error decoding URL:', e)
     return url

--- a/src/background/heartbeat.ts
+++ b/src/background/heartbeat.ts
@@ -21,10 +21,8 @@ function decodeURL(url: string): string {
     const userinfo =
       parsed.username === ''
         ? ''
-        : `${encodeURIComponent(parsed.username)}${
-            parsed.password === ''
-              ? ''
-              : `:${encodeURIComponent(parsed.password)}`
+        : `${parsed.username}${
+            parsed.password === '' ? '' : `:${parsed.password}`
           }@`
     const port = parsed.port === '' ? '' : `:${parsed.port}`
     return `${parsed.protocol}//${userinfo}${decodedHost}${port}${parsed.pathname}${parsed.search}${parsed.hash}`

--- a/src/punycode.d.ts
+++ b/src/punycode.d.ts
@@ -1,0 +1,4 @@
+declare module 'punycode.js' {
+  export function toUnicode(domain: string): string
+  export function toASCII(domain: string): string
+}


### PR DESCRIPTION
Fixes ActivityWatch/aw-watcher-web#71

Non-ASCII domains were stored and shown as punycode (`xn--...`). Decode `xn--` hostnames to Unicode before sending heartbeats so the web activity tab shows the user-friendly URL.