### PR TITLE
Fix heartbeats on active tab URL and title changes

### DIFF
--- a/src/background/heartbeat.ts
+++ b/src/background/heartbeat.ts
@@ -114,24 +114,19 @@ async function heartbeat(
 // transaction so each update observes the preceding update.
 let heartbeatQueue: Promise<void> = Promise.resolve()
 
-function queueHeartbeat(
-  client: AWClient,
-  tab: browser.Tabs.Tab | undefined,
-  tabCount: number,
-  now: Date = new Date(),
-) {
-  const tabSnapshot: HeartbeatTab | undefined = tab
-    ? {
-        url: tab.url,
-        title: tab.title,
-        audible: tab.audible,
-        incognito: tab.incognito,
-      }
-    : undefined
+function snapshotTab(tab: browser.Tabs.Tab): HeartbeatTab {
+  return {
+    url: tab.url,
+    title: tab.title,
+    audible: tab.audible,
+    incognito: tab.incognito,
+  }
+}
 
-  const queuedHeartbeat = heartbeatQueue.then(() =>
-    heartbeat(client, tabSnapshot, tabCount, now),
-  )
+// Call this before starting asynchronous work so queue order matches event
+// order.
+function queueHeartbeat(task: () => Promise<void>) {
+  const queuedHeartbeat = heartbeatQueue.then(task)
 
   // Keep processing later heartbeats if one fails, while still returning the
   // original rejection to the caller.
@@ -140,29 +135,39 @@ function queueHeartbeat(
 }
 
 export const sendInitialHeartbeat = async (client: AWClient) => {
-  const activeWindowTab = await getActiveWindowTab()
-  const tabs = await getTabs()
-  console.debug('Sending initial heartbeat', activeWindowTab?.url)
-  await queueHeartbeat(client, activeWindowTab, tabs.length)
+  const now = new Date()
+  await queueHeartbeat(async () => {
+    const activeWindowTab = await getActiveWindowTab()
+    const tabs = await getTabs()
+    console.debug('Sending initial heartbeat', activeWindowTab?.url)
+    await heartbeat(client, activeWindowTab, tabs.length, now)
+  })
 }
 
 export const heartbeatAlarmListener =
   (client: AWClient) => async (alarm: browser.Alarms.Alarm) => {
     if (alarm.name !== config.heartbeat.alarmName) return
-    const activeWindowTab = await getActiveWindowTab()
-    if (!activeWindowTab) return
-    const tabs = await getTabs()
-    console.debug('Sending heartbeat for alarm', activeWindowTab.url)
-    await queueHeartbeat(client, activeWindowTab, tabs.length)
+
+    const now = new Date()
+    await queueHeartbeat(async () => {
+      const activeWindowTab = await getActiveWindowTab()
+      if (!activeWindowTab) return
+      const tabs = await getTabs()
+      console.debug('Sending heartbeat for alarm', activeWindowTab.url)
+      await heartbeat(client, activeWindowTab, tabs.length, now)
+    })
   }
 
 export const tabActivatedListener =
   (client: AWClient) =>
   async (activeInfo: browser.Tabs.OnActivatedActiveInfoType) => {
-    const tab = await getTab(activeInfo.tabId)
-    const tabs = await getTabs()
-    console.debug('Sending heartbeat for tab activation', tab.url)
-    await queueHeartbeat(client, tab, tabs.length)
+    const now = new Date()
+    await queueHeartbeat(async () => {
+      const tab = await getTab(activeInfo.tabId)
+      const tabs = await getTabs()
+      console.debug('Sending heartbeat for tab activation', tab.url)
+      await heartbeat(client, tab, tabs.length, now)
+    })
   }
 
 export const tabUpdatedListener =
@@ -175,10 +180,13 @@ export const tabUpdatedListener =
     if (changeInfo.url === undefined && changeInfo.title === undefined) return
 
     const now = new Date()
-    const activeWindowTab = await getActiveWindowTab()
-    if (activeWindowTab?.id !== tabId) return
+    const tabSnapshot = snapshotTab(tab)
+    await queueHeartbeat(async () => {
+      const activeWindowTab = await getActiveWindowTab()
+      if (activeWindowTab?.id !== tabId) return
 
-    const tabs = await getTabs()
-    console.debug('Sending heartbeat for tab update', tab.url)
-    await queueHeartbeat(client, tab, tabs.length, now)
+      const tabs = await getTabs()
+      console.debug('Sending heartbeat for tab update', tabSnapshot.url)
+      await heartbeat(client, tabSnapshot, tabs.length, now)
+    })
   }

--- a/src/background/heartbeat.ts
+++ b/src/background/heartbeat.ts
@@ -46,10 +46,16 @@ function formatHeartbeatLogData(data: IEvent['data']) {
     .join(', ')
 }
 
+type HeartbeatTab = Pick<
+  browser.Tabs.Tab,
+  'url' | 'title' | 'audible' | 'incognito'
+>
+
 async function heartbeat(
   client: AWClient,
-  tab: browser.Tabs.Tab | undefined,
+  tab: HeartbeatTab | undefined,
   tabCount: number,
+  now: Date,
 ) {
   const enabled = await getEnabled()
   if (!enabled) {
@@ -72,7 +78,6 @@ async function heartbeat(
   // data URI).  Over thousands of heartbeats the retained Tab references
   // cause unbounded memory growth (see #222).
   const { url, title, audible, incognito } = tab
-  const now = new Date()
   const data: IEvent['data'] = {
     url: decodeURL(url),
     title,
@@ -104,11 +109,41 @@ async function heartbeat(
   await setHeartbeatData(data)
 }
 
+// Chrome can report URL and title changes before a preceding asynchronous
+// heartbeat finishes. Serialize the complete previousData read/send/write
+// transaction so each update observes the preceding update.
+let heartbeatQueue: Promise<void> = Promise.resolve()
+
+function queueHeartbeat(
+  client: AWClient,
+  tab: browser.Tabs.Tab | undefined,
+  tabCount: number,
+  now: Date = new Date(),
+) {
+  const tabSnapshot: HeartbeatTab | undefined = tab
+    ? {
+        url: tab.url,
+        title: tab.title,
+        audible: tab.audible,
+        incognito: tab.incognito,
+      }
+    : undefined
+
+  const queuedHeartbeat = heartbeatQueue.then(() =>
+    heartbeat(client, tabSnapshot, tabCount, now),
+  )
+
+  // Keep processing later heartbeats if one fails, while still returning the
+  // original rejection to the caller.
+  heartbeatQueue = queuedHeartbeat.catch(() => undefined)
+  return queuedHeartbeat
+}
+
 export const sendInitialHeartbeat = async (client: AWClient) => {
   const activeWindowTab = await getActiveWindowTab()
   const tabs = await getTabs()
   console.debug('Sending initial heartbeat', activeWindowTab?.url)
-  await heartbeat(client, activeWindowTab, tabs.length)
+  await queueHeartbeat(client, activeWindowTab, tabs.length)
 }
 
 export const heartbeatAlarmListener =
@@ -118,7 +153,7 @@ export const heartbeatAlarmListener =
     if (!activeWindowTab) return
     const tabs = await getTabs()
     console.debug('Sending heartbeat for alarm', activeWindowTab.url)
-    await heartbeat(client, activeWindowTab, tabs.length)
+    await queueHeartbeat(client, activeWindowTab, tabs.length)
   }
 
 export const tabActivatedListener =
@@ -127,5 +162,23 @@ export const tabActivatedListener =
     const tab = await getTab(activeInfo.tabId)
     const tabs = await getTabs()
     console.debug('Sending heartbeat for tab activation', tab.url)
-    await heartbeat(client, tab, tabs.length)
+    await queueHeartbeat(client, tab, tabs.length)
+  }
+
+export const tabUpdatedListener =
+  (client: AWClient) =>
+  async (
+    tabId: number,
+    changeInfo: browser.Tabs.OnUpdatedChangeInfoType,
+    tab: browser.Tabs.Tab,
+  ) => {
+    if (changeInfo.url === undefined && changeInfo.title === undefined) return
+
+    const now = new Date()
+    const activeWindowTab = await getActiveWindowTab()
+    if (activeWindowTab?.id !== tabId) return
+
+    const tabs = await getTabs()
+    console.debug('Sending heartbeat for tab update', tab.url)
+    await queueHeartbeat(client, tab, tabs.length, now)
   }

--- a/src/background/main.ts
+++ b/src/background/main.ts
@@ -4,6 +4,7 @@ import {
   heartbeatAlarmListener,
   sendInitialHeartbeat,
   tabActivatedListener,
+  tabUpdatedListener,
 } from './heartbeat'
 import { getClient, detectHostname, loadApiKey } from './client'
 import {
@@ -73,6 +74,10 @@ browser.alarms.onAlarm.addListener(async (alarm) => {
 browser.tabs.onActivated.addListener(async (activeInfo) => {
   await clientReady
   return tabActivatedListener(client)(activeInfo)
+})
+browser.tabs.onUpdated.addListener(async (tabId, changeInfo, tab) => {
+  await clientReady
+  return tabUpdatedListener(client)(tabId, changeInfo, tab)
 })
 
 console.debug('Setting base url')


### PR DESCRIPTION
### Before
Normal Reddit browsing produces many zero-duration or very short events:

<img width="773" height="700" alt="ActivityWatch Reddit timeline before the fix" src="https://github.com/user-attachments/assets/a0f06e46-4264-4b02-a90e-1962823264e5" />

### After


<img width="773" height="707" alt="ActivityWatch Reddit timeline after the fix" src="https://github.com/user-attachments/assets/a3c45cc4-b808-45d5-8b97-16ab725b0b3b" />

Heartbeats were previously triggered by extension startup, the periodic alarm, and tab activation. Navigation within a single-page application can change the active tab's URL and title without activating a different tab.

As a result, the existing `previousData` logic was not necessarily run at the time of navigation. When browsing sites like Reddit, this can produce missing or very short raw events.

To fix this, Chrome can also report the URL and title portions of one navigation as separate, closely spaced `tabs.onUpdated` callbacks. Since heartbeat processing is asynchronous, those callbacks must be serialized so each heartbeat sees the data stored by the preceding one.

## Solution

Listen for URL and title changes through `tabs.onUpdated`, while filtering out updates that do not belong to the active tab in the active window.

The update timestamp is captured before asynchronous tab queries. All heartbeat sources then pass through a small queue, allowing the existing logic to extend `previousData` up to that timestamp before beginning the new event.

This preserves the detailed URL and title of each event and does not add domain- or site-specific behavior.

Disclaimer -- this PR was created with the assistance of Codex. 