### PR TITLE
ci: fix build-safari failure with Xcode 26 by normalizing bundle identifiers

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -79,6 +79,8 @@ jobs:
             "$PBXPROJ"
           grep -n 'PRODUCT_BUNDLE_IDENTIFIER' "$PBXPROJ"
           grep -q "PRODUCT_BUNDLE_IDENTIFIER = ${BUNDLE_ID};" "$PBXPROJ"
+          grep -q "PRODUCT_BUNDLE_IDENTIFIER = ${BUNDLE_ID}.Extension;" "$PBXPROJ"
+          ! grep 'PRODUCT_BUNDLE_IDENTIFIER' "$PBXPROJ" | grep -vE "= ${BUNDLE_ID}(\.Extension)?;$"
 
       - name: Build Xcode Project
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -63,6 +63,23 @@ jobs:
             --macos-only \
             --force
 
+      # Xcode 26's safari-web-extension-converter applies --bundle-identifier
+      # only to the extension target and derives the app target's identifier
+      # from the app name (net.activitywatch.ActivityWatch-Web-Watcher), which
+      # fails ValidateEmbeddedBinary ("Embedded binary's bundle identifier is
+      # not prefixed with the parent app's bundle identifier"). Force both
+      # targets to the intended identifiers.
+      - name: Normalize bundle identifiers
+        run: |
+          BUNDLE_ID="net.activitywatch.activitywatchwebwatcher"
+          PBXPROJ="ActivityWatch Web Watcher/ActivityWatch Web Watcher.xcodeproj/project.pbxproj"
+          sed -i '' -E \
+            -e "s/(PRODUCT_BUNDLE_IDENTIFIER = )\"?[^;\"]+\.Extension\"?;/\1${BUNDLE_ID}.Extension;/" \
+            -e "/\.Extension;/!s/(PRODUCT_BUNDLE_IDENTIFIER = )\"?[^;\"]+\"?;/\1${BUNDLE_ID};/" \
+            "$PBXPROJ"
+          grep -n 'PRODUCT_BUNDLE_IDENTIFIER' "$PBXPROJ"
+          grep -q "PRODUCT_BUNDLE_IDENTIFIER = ${BUNDLE_ID};" "$PBXPROJ"
+
       - name: Build Xcode Project
         run: |
           xcodebuild -project "ActivityWatch Web Watcher/ActivityWatch Web Watcher.xcodeproj" -list


### PR DESCRIPTION
## Problem

`build-safari` has failed on every master push since late July (first red: #236 on 2026-07-29), turning master CI red. No safari-related code changed — the cause is the `macos-latest` runner image moving to Xcode 26.

With Xcode 26, `safari-web-extension-converter` applies `--bundle-identifier` only to the **extension** target and derives the **app** target's identifier from the app name instead:

```
error: Embedded binary's bundle identifier is not prefixed with the parent app's bundle identifier.

    Embedded Binary Bundle Identifier:  net.activitywatch.activitywatchwebwatcher.Extension
    Parent App Bundle Identifier:       net.activitywatch.ActivityWatch-Web-Watcher
```

## Fix

Add a step after conversion that rewrites `PRODUCT_BUNDLE_IDENTIFIER` in the generated `project.pbxproj` so both targets use the intended identifiers (`net.activitywatch.activitywatchwebwatcher` / `…​.Extension`), then asserts the result. This fixes the root cause rather than pinning the runner to an older macOS image, and is a no-op if/when Apple fixes the converter.