### PR TITLE
feat(popup): add dismissable community support nudge

### DIFF
--- a/src/popup/index.html
+++ b/src/popup/index.html
@@ -92,7 +92,9 @@
           >
           <button
             id="support-nudge-dismiss"
+            type="button"
             title="Dismiss"
+            aria-label="Dismiss support message"
             style="
               background: none;
               border: none;

--- a/src/popup/index.html
+++ b/src/popup/index.html
@@ -83,6 +83,33 @@
 
     <hr />
 
+    <div id="support-nudge" style="display: none">
+      <small>
+        <p>
+          ActivityWatch is community-funded —
+          <a href="https://activitywatch.net/go/?src=webext" target="_blank"
+            >support it ❤️</a
+          >
+          <button
+            id="support-nudge-dismiss"
+            title="Dismiss"
+            style="
+              background: none;
+              border: none;
+              cursor: pointer;
+              color: #888;
+              font-size: 1em;
+              padding: 0 0.2em;
+              vertical-align: middle;
+            "
+          >
+            ×
+          </button>
+        </p>
+      </small>
+      <hr />
+    </div>
+
     <small>
       <p>
         If you find any bugs with this watcher, please report them

--- a/src/popup/main.ts
+++ b/src/popup/main.ts
@@ -116,17 +116,29 @@ function domListeners() {
 }
 
 async function initSupportNudge() {
-  const result = await browser.storage.local.get('supportNudgeDismissed')
-  if (result.supportNudgeDismissed) return
-
   const nudge = document.getElementById('support-nudge')
   if (!nudge) return
+
+  let dismissed = false
+  try {
+    const result = await browser.storage.local.get('supportNudgeDismissed')
+    dismissed = Boolean(result.supportNudgeDismissed)
+  } catch (error) {
+    console.error('Failed to read support nudge state:', error)
+  }
+  if (dismissed) return
+
   nudge.style.removeProperty('display')
 
   const dismiss = document.getElementById('support-nudge-dismiss')
   dismiss?.addEventListener('click', async () => {
-    await browser.storage.local.set({ supportNudgeDismissed: true })
+    // Hide first so a failed persist still honors the click this session.
     nudge.style.setProperty('display', 'none')
+    try {
+      await browser.storage.local.set({ supportNudgeDismissed: true })
+    } catch (error) {
+      console.error('Failed to persist support nudge dismissal:', error)
+    }
   })
 }
 

--- a/src/popup/main.ts
+++ b/src/popup/main.ts
@@ -115,5 +115,21 @@ function domListeners() {
   })
 }
 
+async function initSupportNudge() {
+  const result = await browser.storage.local.get('supportNudgeDismissed')
+  if (result.supportNudgeDismissed) return
+
+  const nudge = document.getElementById('support-nudge')
+  if (!nudge) return
+  nudge.style.removeProperty('display')
+
+  const dismiss = document.getElementById('support-nudge-dismiss')
+  dismiss?.addEventListener('click', async () => {
+    await browser.storage.local.set({ supportNudgeDismissed: true })
+    nudge.style.setProperty('display', 'none')
+  })
+}
+
 renderStatus()
 domListeners()
+initSupportNudge()


### PR DESCRIPTION
## Summary

Adds a tasteful, one-line footer link to the extension popup so the 40k+ weekly-active users see a funding nudge.

**Link text:** `ActivityWatch is community-funded — support it ❤️`
**Link URL:** `https://activitywatch.net/go/?src=webext`

## Behavior

- Shown by default on first popup open
- Dismissed via × button; dismissal stored in `browser.storage.local`
- Dismissed state is permanent across popup close/reopen
- No phone-home, no behavioral change beyond showing/hiding a link
- `?src=webext` source tag enables funnel attribution

## Why now

The extension just shipped 0.6.0 with a tag-triggered store release pipeline. It's the largest active-user surface (~40k WAU) carrying zero Pro/support capture. The desktop release (v0.14.0) is still pending, so every week without this nudge in the extension is missed reach.

## Changes

- `src/popup/index.html` — adds `#support-nudge` div with link + dismiss button (hidden by default)
- `src/popup/main.ts` — adds `initSupportNudge()` that reads/writes `supportNudgeDismissed` in `browser.storage.local`

TypeScript compilation clean (`tsc --noEmit`).